### PR TITLE
Add first draft of event stream over websockets

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -46,7 +46,7 @@ class Network(Resource):
             'name': self.trustlines.currency_network_proxies[network_address].name,
             'abbreviation': self.trustlines.currency_network_proxies[network_address].symbol,
             'decimals': self.trustlines.currency_network_proxies[network_address].decimals,
-            'numUsers': len(self.trustlines.currency_network_proxies[network_address].users)
+            'numUsers': len(self.trustlines.currency_network_graphs[network_address].users)
         }
 
 
@@ -176,7 +176,7 @@ class UserEventsNetwork(Resource):
             events = proxy.get_network_events(type, user_address, from_block=from_block)
         else:
             events = proxy.get_all_network_events(user_address, from_block=from_block)
-        return UserCurrencyNetworkEventSchema().dump(events, many=True)
+        return UserCurrencyNetworkEventSchema().dump(events, many=True).data
 
 
 class UserEvents(Resource):
@@ -203,7 +203,7 @@ class UserEvents(Resource):
                 events = events + proxy.get_network_events(type, user_address, from_block=from_block)
             else:
                 events = events + proxy.get_all_network_events(user_address, from_block=from_block)
-        return UserCurrencyNetworkEventSchema().dump(events, many=True)
+        return UserCurrencyNetworkEventSchema().dump(events, many=True).data
 
 
 class EventsNetwork(Resource):
@@ -228,7 +228,7 @@ class EventsNetwork(Resource):
             events = proxy.get_events(type, from_block=from_block)
         else:
             events = proxy.get_all_events(from_block=from_block)
-        return CurrencyNetworkEventSchema().dump(events, many=True)
+        return CurrencyNetworkEventSchema().dump(events, many=True).data
 
 
 class TransactionInfos(Resource):

--- a/relay/api/schemas.py
+++ b/relay/api/schemas.py
@@ -4,6 +4,8 @@ from .fields import Address, BigInteger
 
 
 class EventSchema(Schema):
+    class Meta:
+        strict = True
     timestamp = fields.Integer()
 
 

--- a/relay/api/streams/app.py
+++ b/relay/api/streams/app.py
@@ -1,0 +1,20 @@
+from functools import partial
+
+from tinyrpc.dispatch import RPCDispatcher
+from tinyrpc.protocols.jsonrpc import JSONRPCProtocol
+
+from .rpc_methods import subscribe
+from .transport import RPCWebSocketApplication
+
+
+def WebSocketRPCHandler(trustlines):
+
+    dispatcher = RPCDispatcher()
+    dispatcher.add_method(partial(subscribe, trustlines), 'subscribe')
+
+    protocol = JSONRPCProtocol()
+
+    def handle(ws):
+        app = RPCWebSocketApplication(protocol, dispatcher, ws)
+        app.handle()
+    return handle

--- a/relay/api/streams/rpc_methods.py
+++ b/relay/api/streams/rpc_methods.py
@@ -1,0 +1,20 @@
+from marshmallow import fields, Schema, ValidationError
+
+from .rpc_protocol import check_args
+from ..fields import Address
+
+
+class SubscribeSchema(Schema):
+    class Meta:
+        strict = True
+    event = fields.String(required=True)
+    user = Address(required=True)
+
+
+@check_args(SubscribeSchema())
+def subscribe(trustlines, client, event, user):
+    if event == 'all':
+        subscriber = trustlines.subjects[user].subscribe(client)
+    else:
+        raise ValidationError('Invalid event')
+    return subscriber.id

--- a/relay/api/streams/rpc_protocol.py
+++ b/relay/api/streams/rpc_protocol.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+from tinyrpc.protocols.jsonrpc import JSONRPCInvalidParamsError
+from marshmallow import ValidationError
+
+
+def validating_rpc_caller(method, args, kwargs, client):
+    if len(args) > 0:
+        raise JSONRPCInvalidParamsError('No positional arguments allowed')
+    try:
+        return method(client, **kwargs)
+    except ValidationError as e:
+        raise JSONRPCInvalidParamsError('Invalid params:'+str(e.messages))
+    except Exception as e:
+        raise Exception('Internal server error: ' + str(e))
+
+
+def check_args(schema):
+    def check_args_decorator(func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            data = schema.load(kwargs).data
+            return func(*args, **data)
+        return func_wrapper
+    return check_args_decorator

--- a/relay/api/streams/transport.py
+++ b/relay/api/streams/transport.py
@@ -1,0 +1,60 @@
+import logging
+
+from geventwebsocket import WebSocketApplication, WebSocketError
+from tinyrpc import BadRequestError
+
+from relay.streams import Client, DisconnectedError
+from .rpc_protocol import validating_rpc_caller
+from ..schemas import UserCurrencyNetworkEventSchema
+from relay.logger import get_logger
+
+logger = get_logger('websockets', logging.DEBUG)
+
+
+class RPCWebSocketApplication(WebSocketApplication):
+
+    def __init__(self, rpc_protocol, dispatcher, ws):
+        super().__init__(ws)
+        self.rpc = rpc_protocol
+        self.dispatcher = dispatcher
+
+    def on_open(self):
+        logger.debug('Websocket connected')
+
+    def on_message(self, message):
+
+        def caller(method, args, kwargs):
+            return validating_rpc_caller(method, args, kwargs, client=RPCWebSocketClient(self.ws, self.rpc))
+
+        try:
+            request = self.rpc.parse_request(message)
+        except BadRequestError as e:
+            # request was invalid, directly create response
+            response = e.error_respond()
+        else:
+            response = self.dispatcher.dispatch(request, caller=caller)
+
+        # now send the response to the client
+        if response is not None:
+            try:
+                self.ws.send(response.serialize())
+            except WebSocketError:
+                pass
+
+    def on_close(self, reason):
+        logger.debug('Websocket disconnected')
+
+
+class RPCWebSocketClient(Client):
+
+    def __init__(self, ws, rpc_protocol):
+        self.ws = ws
+        self.rpc = rpc_protocol
+
+    def send(self, id, event):
+        event = UserCurrencyNetworkEventSchema().dump(event).data
+        request = self.rpc.create_request('subscription_' + str(id), args={'event': event}, one_way=True)
+        try:
+            self.ws.send(request.serialize())
+        except WebSocketError as e:
+            raise DisconnectedError from e

--- a/relay/blockchain/currency_network_events.py
+++ b/relay/blockchain/currency_network_events.py
@@ -90,7 +90,8 @@ event_builders = {
     CreditlineRequestEventType: CreditlineRequestEvent,
     CreditlineUpdateEventType: CreditlineUpdateEvent,
     TrustlineUpdateEventType: TrustlineUpdateEvent,
-    TrustlineRequestEventType: TrustlineRequestEvent
+    TrustlineRequestEventType: TrustlineRequestEvent,
+    BalanceUpdateEventType: BalanceUpdateEvent,
 }
 
 

--- a/relay/blockchain/currency_network_events.py
+++ b/relay/blockchain/currency_network_events.py
@@ -54,6 +54,10 @@ class TransferEvent(ValueEvent):
     pass
 
 
+class BalanceUpdateEvent(ValueEvent):
+    pass
+
+
 class CreditlineUpdateEvent(ValueEvent):
     pass
 
@@ -96,4 +100,5 @@ from_to_types = {
     CreditlineUpdateEventType: ['_creditor', '_debtor'],
     TrustlineRequestEventType: ['_creditor', '_debtor'],
     TrustlineUpdateEventType: ['_creditor', '_debtor'],
+    BalanceUpdateEventType: ['_from',  '_to'],
 }

--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -38,18 +38,9 @@ class CurrencyNetworkProxy(Proxy):
 
     def __init__(self, web3, abi, address):
         super().__init__(web3, abi, address)
-
-    @property
-    def name(self):
-        return self._proxy.call().name().strip('\0')
-
-    @property
-    def decimals(self):
-        return self._proxy.call().decimals()
-
-    @property
-    def symbol(self):
-        return self._proxy.call().symbol().strip('\0')
+        self.name = self._proxy.call().name().strip('\0')
+        self.decimals = self._proxy.call().decimals()
+        self.symbol = self._proxy.call().symbol().strip('\0')
 
     @property
     def users(self):
@@ -111,27 +102,24 @@ class CurrencyNetworkProxy(Proxy):
 
     def start_listen_on_balance(self, f):
         def log(log_entry):
-            f(log_entry['args']['_from'], log_entry['args']['_to'], log_entry['args']['_value'])
+            f(self._build_event(log_entry))
         self.start_listen_on(BalanceUpdateEventType, log)
 
     def start_listen_on_creditline(self, f):
         def log_creditline(log_entry):
-            f(log_entry['args']['_creditor'], log_entry['args']['_debtor'], log_entry['args']['_value'])
+            f(self._build_event(log_entry))
 
         self.start_listen_on(CreditlineUpdateEventType, log_creditline)
 
     def start_listen_on_trustline(self, f):
         def log_trustline(log_entry):
-            f(log_entry['args']['_creditor'],
-              log_entry['args']['_debtor'],
-              log_entry['args']['_creditlineGiven'],
-              log_entry['args']['_creditlineReceived'])
+            f(self._build_event(log_entry))
 
         self.start_listen_on(TrustlineUpdateEventType, log_trustline)
 
     def start_listen_on_transfer(self, f):
         def log(log_entry):
-            f(log_entry['args']['_from'], log_entry['args']['_to'], log_entry['args']['_value'])
+            f(self._build_event(log_entry))
         self.start_listen_on(TransferEventType, log)
 
     def get_network_events(self, event_name, user_address=None, from_block=0):

--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -8,10 +8,12 @@ from .proxy import Proxy, reconnect_interval, sorted_events
 from relay.logger import get_logger
 
 from .currency_network_events import (
-    TransferEventType,
     CreditlineUpdateEventType,
+    CreditlineRequestEventType,
     TrustlineUpdateEventType,
+    TrustlineRequestEventType,
     BalanceUpdateEventType,
+    TransferEventType,
     from_to_types,
     event_builders,
 )
@@ -35,6 +37,12 @@ class CurrencyNetworkProxy(Proxy):
 
     event_builders = event_builders
     event_types = list(event_builders.keys())
+
+    standard_event_types = [TransferEventType,
+                            CreditlineRequestEventType,
+                            CreditlineUpdateEventType,
+                            TrustlineRequestEventType,
+                            TrustlineUpdateEventType]
 
     def __init__(self, web3, abi, address):
         super().__init__(web3, abi, address)
@@ -139,7 +147,7 @@ class CurrencyNetworkProxy(Proxy):
 
     def get_all_network_events(self, user_address=None, from_block=0):
         all_events = []
-        for type in self.event_builders.keys():    # FIXME takes too long.
+        for type in self.standard_event_types:    # FIXME takes too long.
                                                     # web3.py currently doesn't support getAll() to retrieve all events
             all_events = all_events + self.get_network_events(type, user_address, from_block)
         return sorted_events(all_events)

--- a/relay/blockchain/proxy.py
+++ b/relay/blockchain/proxy.py
@@ -18,6 +18,7 @@ reconnect_interval = 3  # 3s
 
 class Proxy(object):
     event_builders = {}
+    standard_event_types = []
 
     def __init__(self, web3, abi, address):
         self._web3 = web3
@@ -71,7 +72,7 @@ class Proxy(object):
 
     def get_all_events(self, filter_=None, from_block=0):
         all_events = []
-        for type in self.event_builders.keys():  # FIXME takes too long.
+        for type in self.standard_event_types:  # FIXME takes too long.
             # web3.py currently doesn't support getAll() to retrieve all events
             all_events = all_events + self.get_events(type, filter_=filter_, from_block=from_block)
         return sorted_events(all_events)

--- a/relay/streams.py
+++ b/relay/streams.py
@@ -1,0 +1,60 @@
+import random
+import logging
+
+from .logger import get_logger
+
+logger = get_logger('streams', logging.DEBUG)
+
+
+class Client():
+
+    def send(self, id, event):
+        raise NotImplementedError
+
+
+class DisconnectedError(Exception):
+    pass
+
+
+class Subject():
+
+    def __init__(self):
+        self.subscriptions = []
+
+    def subscribe(self, client):
+        logger.debug('New Subscription')
+        subscription = Subscription(client, self._create_id(), self)
+        self.subscriptions.append(subscription)
+        return subscription
+
+    def unsubscribe(self, subscription):
+        logger.debug('Unsubscription')
+        self.subscriptions.remove(subscription)
+
+    def publish(self, event):
+        logger.debug('Sent event to {} subscribers'.format(len(self.subscriptions)))
+        for subscription in self.subscriptions:
+            subscription.notify(event)
+
+    @staticmethod
+    def _create_id():
+        return '0x{:016X}'.format(random.randint(0, 16**16-1))
+
+
+class Subscription():
+    def __init__(self, client, id, subject):
+        self.client = client
+        self.id = id
+        self.subject = subject
+        self.closed = False
+
+    def notify(self, event):
+        if not self.closed:
+            try:
+                self.client.send(self.id, event)
+            except DisconnectedError:
+                self.unsubscribe()
+
+    def unsubscribe(self):
+        self.closed = True
+        self.subject.unsubscribe(self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ eth-testrpc
 git+https://github.com/trustlines-network/contracts.git@develop
 sqlalchemy
 eth-utils==0.7.4
+tinyrpc
+gevent-websocket
+marshmallow
+flask-sockets

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -96,8 +96,8 @@ def test_listen_on_creditline_update(fresh_currency_network, accounts):
     currency_network = fresh_currency_network
     events = []
 
-    def f(from_, to, value):
-        events.append((from_, to, value))
+    def f(event):
+        events.append(event)
 
     currency_network.start_listen_on_creditline(f)
     context_switch()
@@ -106,15 +106,17 @@ def test_listen_on_creditline_update(fresh_currency_network, accounts):
     gevent.sleep(1)
 
     assert len(events) == 1
-    assert events[0] == (accounts[0], accounts[1], 25)
+    assert events[0].from_ == accounts[0]
+    assert events[0].to == accounts[1]
+    assert events[0].value == 25
 
 
 def test_listen_on_balance_update(fresh_currency_network, accounts):
     currency_network = fresh_currency_network
     events = []
 
-    def f(from_, to, value):
-        events.append((from_, to, value))
+    def f(event):
+        events.append(event)
 
     currency_network.start_listen_on_balance(f)
     context_switch()
@@ -124,17 +126,17 @@ def test_listen_on_balance_update(fresh_currency_network, accounts):
     gevent.sleep(1)
 
     assert len(events) == 1
-    assert (events[0][0] == accounts[0] or events[0][0] == accounts[1])
-    assert (events[0][1] == accounts[0] or events[0][1] == accounts[1])
-    assert (-12 < events[0][2] < 12)  # because there might be fees
+    assert (events[0].from_ == accounts[0] or events[0].from_ == accounts[1])
+    assert (events[0].to == accounts[0] or events[0].to == accounts[1])
+    assert (-12 < events[0].value < 12)  # because there might be fees
 
 
 def test_listen_on_transfer(fresh_currency_network, accounts):
     currency_network = fresh_currency_network
     events = []
 
-    def f(from_, to, value):
-        events.append((from_, to, value))
+    def f(event):
+        events.append(event)
 
     currency_network.start_listen_on_transfer(f)
     context_switch()
@@ -144,15 +146,17 @@ def test_listen_on_transfer(fresh_currency_network, accounts):
     gevent.sleep(1)
 
     assert len(events) == 1
-    assert events[0] == (accounts[1], accounts[0], 10)
+    assert events[0].from_ == accounts[1]
+    assert events[0].to == accounts[0]
+    assert events[0].value == 10
 
 
 def test_listen_on_trustline_update(fresh_currency_network, accounts):
     currency_network = fresh_currency_network
     events = []
 
-    def f(from_, to, given, received):
-        events.append((from_, to, given, received))
+    def f(event):
+        events.append(event)
 
     currency_network.start_listen_on_trustline(f)
     context_switch()
@@ -161,4 +165,7 @@ def test_listen_on_trustline_update(fresh_currency_network, accounts):
     gevent.sleep(1)
 
     assert len(events) == 1
-    assert events[0] == (accounts[1], accounts[0], 50, 25)
+    assert events[0].from_ == accounts[0]
+    assert events[0].to == accounts[1]
+    assert events[0].given == 25
+    assert events[0].received == 50

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -2,7 +2,42 @@ import pytest
 import gevent
 
 from relay.network_graph.graph import CurrencyNetworkGraph
-from relay.main import link_graph
+
+
+def link_graph(proxy, graph, full_sync_interval=None):
+    if full_sync_interval is not None:
+        proxy.start_listen_on_full_sync(_create_on_full_sync(graph), full_sync_interval)
+    proxy.start_listen_on_balance(_create_on_balance(graph))
+    proxy.start_listen_on_creditline(_create_on_creditline(graph))
+    proxy.start_listen_on_trustline(_create_on_trustline(graph))
+
+
+def _create_on_balance(graph):
+    def update_balance(event):
+        graph.update_balance(event.from_, event.to, event.value)
+
+    return update_balance
+
+
+def _create_on_creditline(graph):
+    def update_creditline(event):
+        graph.update_creditline(event.from_, event.to, event.value)
+
+    return update_creditline
+
+
+def _create_on_trustline(graph):
+    def update_trustline(event):
+        graph.update_trustline(event.from_, event.to, event.given, event.received)
+
+    return update_trustline
+
+
+def _create_on_full_sync(graph):
+    def update_community(graph_rep):
+        graph.gen_network(graph_rep)
+
+    return update_community
 
 
 @pytest.fixture()

--- a/tests/unit/test_streams.py
+++ b/tests/unit/test_streams.py
@@ -1,0 +1,51 @@
+import pytest
+
+from relay.streams import Client, Subject, DisconnectedError
+
+
+class TestClient(Client):
+
+    def __init__(self):
+        self.events = []
+
+    def send(self, id, event):
+        if event == 'disconnect':
+            raise DisconnectedError
+        self.events.append((id, event))
+
+
+@pytest.fixture()
+def subject():
+    return Subject()
+
+
+@pytest.fixture()
+def client():
+    return TestClient()
+
+
+def test_subscription(subject, client):
+    subscribtion = subject.subscribe(client)
+    subject.publish(event='test')
+    id = subscribtion.id
+    assert client.events == [(id, 'test')]
+    assert not subscribtion.closed
+    assert len(subject.subscriptions) == 1
+
+
+def test_cancel_subscription(subject, client):
+    subscribtion = subject.subscribe(client)
+    subscribtion.unsubscribe()
+    subject.publish(event='test')
+    assert client.events == []
+    assert subscribtion.closed
+    assert len(subject.subscriptions) == 0
+
+
+def test_auto_unsubscribe(subject, client):
+    subscribtion = subject.subscribe(client)
+    subject.publish(event='disconnect')  # throws disconnected error, should unsubscribe
+    subject.publish(event='test')
+    assert client.events == []
+    assert subscribtion.closed
+    assert len(subject.subscriptions) == 0


### PR DESCRIPTION
Add first draft of event stream over websockets. 
Use jsonrpc as protocol for the messages. 
Only method implemented so far is subscribe with parameters event and user, to subscribe to all events for a user. 
Currently implemented events: Update and requests of creditlines, trustlines and balances of trustlines, transfers