### PR TITLE
Concurrent event fetching

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -198,7 +198,7 @@ class UserEvents(Resource):
 
     @use_args(args)
     def get(self, args, user_address: str):
-        events = []  # type: List[BlockchainEvent]
+        events = []
         type = args['type']
         from_block = args['fromBlock']
         networks = self.trustlines.networks
@@ -211,8 +211,8 @@ class UserEvents(Resource):
                                            from_block=from_block))
             else:
                 events.append(gevent.spawn(proxy.get_all_network_events,
-                              user_address=user_address,
-                              from_block=from_block))
+                                           user_address=user_address,
+                                           from_block=from_block))
         gevent.joinall(events, timeout=5)
         flattened_events = list(itertools.chain.from_iterable([event.value for event in events]))
         return UserCurrencyNetworkEventSchema().dump(flattened_events, many=True).data

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -205,17 +205,18 @@ class UserEvents(Resource):
         for network_address in networks:
             proxy = self.trustlines.currency_network_proxies[network_address]
             if type is not None:
-                events.append(gevent.spawn(proxy.get_network_events,    
+                events.append(gevent.spawn(proxy.get_network_events,
                                            type,
                                            user_address=user_address,
                                            from_block=from_block))
             else:
                 events.append(gevent.spawn(proxy.get_all_network_events,
-                             user_address=user_address,
-                             from_block=from_block))
+                              user_address=user_address,
+                              from_block=from_block))
         gevent.joinall(events, timeout=5)
         flattened_events = list(itertools.chain.from_iterable([event.value for event in events]))
         return UserCurrencyNetworkEventSchema().dump(flattened_events, many=True).data
+
 
 class EventsNetwork(Resource):
 

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -7,6 +7,8 @@ from flask_restful import Resource
 from webargs import fields
 from webargs.flaskparser import use_args
 from marshmallow import validate
+import gevent
+import itertools
 
 from relay.utils import sha3
 from relay.blockchain.currency_network_proxy import CurrencyNetworkProxy
@@ -203,11 +205,17 @@ class UserEvents(Resource):
         for network_address in networks:
             proxy = self.trustlines.currency_network_proxies[network_address]
             if type is not None:
-                events = events + proxy.get_network_events(type, user_address, from_block=from_block)
+                events.append(gevent.spawn(proxy.get_network_events,    
+                                           type,
+                                           user_address=user_address,
+                                           from_block=from_block))
             else:
-                events = events + proxy.get_all_network_events(user_address, from_block=from_block)
-        return UserCurrencyNetworkEventSchema().dump(events, many=True).data
-
+                events.append(gevent.spawn(proxy.get_all_network_events,
+                             user_address=user_address,
+                             from_block=from_block))
+        gevent.joinall(events, timeout=5)
+        flattened_events = list(itertools.chain.from_iterable([event.value for event in events]))
+        return UserCurrencyNetworkEventSchema().dump(flattened_events, many=True).data
 
 class EventsNetwork(Resource):
 

--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -160,7 +160,7 @@ class CurrencyNetworkProxy(Proxy):
             ]
             gevent.joinall(events, timeout=2)
             result = list(itertools.chain.from_iterable([event.value for event in events]))
-            
+
             for event in result:
                 if isinstance(event, CurrencyNetworkEvent):
                     event.user = user_address


### PR DESCRIPTION
Closes #68 

- spawns multiple greenlets now when fetching events from the blockchain
- response time lowered significantly using this approach (for some local tests the measurements were: `before -> ~ 2000ms`  `after -> 600ms`)