### PR TITLE
log errors from load addresses, do not fail silently

### DIFF
--- a/relay/relay.py
+++ b/relay/relay.py
@@ -56,7 +56,7 @@ class TrustlinesRelay:
         self._load_config()
         self._load_contracts()
         self._load_orderbook()
-        logger.info('using RPCProvider with parameters %s' % self.config['rpc'])
+        logger.info('using RPCProvider with parameters {}'.format(self.config['rpc']))
         self._web3 = Web3(
             RPCProvider(
                 self.config['rpc']['host'],

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -56,6 +56,7 @@ class TrustlinesRelay:
         self._load_config()
         self._load_contracts()
         self._load_orderbook()
+        logger.info('using RPCProvider with parameters %s' % self.config['rpc'])
         self._web3 = Web3(
             RPCProvider(
                 self.config['rpc']['host'],
@@ -140,7 +141,10 @@ class TrustlinesRelay:
     def _start_listen_on_new_addresses(self):
         def listen():
             while True:
-                self._load_addresses()
+                try:
+                    self._load_addresses()
+                except Exception:
+                    logger.critical("Error while loading addresses", exc_info=sys.exc_info())
                 sleep(self.config.get('updateNetworksInterval', 120))
 
         gevent.Greenlet.spawn(listen)

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -119,12 +119,13 @@ class TrustlinesRelay:
         with open('addresses.json') as data_file:
             try:
                 addresses = json.load(data_file)
-                for address in addresses['networks']:
-                    self.new_network(to_checksum_address(address))
-                self.new_exchange(to_checksum_address(addresses['exchange']))
-                self.new_unw_eth(to_checksum_address(addresses['unwEth']))
             except json.decoder.JSONDecodeError as e:
                 logger.error('Could not read addresses.json:' + str(e))
+                return
+        for address in addresses['networks']:
+            self.new_network(to_checksum_address(address))
+        self.new_exchange(to_checksum_address(addresses['exchange']))
+        self.new_unw_eth(to_checksum_address(addresses['unwEth']))
 
     def _start_listen_network(self, address):
         assert is_checksum_address(address)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
+@pytest.fixture(scope="session", autouse=True)
+def silence_deprecation_warnings():
+    from relay.main import patch_warnings_module
+    patch_warnings_module()
+
+
 @pytest.fixture()
 def addresses() -> Sequence[str]:
     return [


### PR DESCRIPTION
When starting tl-relay with a non-existent rpc.host configured in config.json,
_load_addresses will raise an exception and the greenlet started in
_start_listen_on_new_addresses will exit.

All of this happens without a single thing being logged:
,----
| 2018-05-29 22:27:40,941[INFO] trustlines: Starting relay server
| 2018-05-29 22:27:40,987[INFO] trustlines: Server is running on ('', 5000)
| 2018-05-29 22:27:40,999[INFO] relay: New network: 0x55bdaAf9f941A5BB3EacC8D876eeFf90b90ddac9
`----

So, we now catch errors, log them and let the greenlet retry after it's sleep
period.

Also log the parameters used for connecting to the RPC host.