### PR TITLE
Add config option to enable/disable faucet

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,5 +6,6 @@
     "ssl": false
   },
   "syncInterval": 300,
-  "updateNetworksInterval": 120
+  "updateNetworksInterval": 120,
+  "enableEtherFaucet": false
 }

--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -60,7 +60,9 @@ def ApiApp(trustlines):
 
     add_resource(Block, '/blocknumber')
     add_resource(Relay, '/relay')
-    add_resource(RequestEther, '/request-ether')
+
+    if trustlines.enable_ether_faucet:
+        add_resource(RequestEther, '/request-ether')
 
     add_resource(OrderBook, '/exchange/orderbook')
     add_resource(OrderSubmission, '/exchange/order')

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -46,6 +46,10 @@ class TrustlinesRelay:
     def exchanges(self) -> Iterable[str]:
         return self.orderbook.exchange_addresses
 
+    @property
+    def enable_ether_faucet(self) -> bool:
+        return self.config.get('enableEtherFaucet', False)
+
     def is_currency_network(self, address: str) -> bool:
         return address in self.networks
 


### PR DESCRIPTION
I added an option to disable the ether faucet. This allows us to use the same version for easy dev testing and the testnet. 