### PR TITLE
fix usage of gevent.joinall, increase timeouts

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -213,8 +213,8 @@ class UserEvents(Resource):
                 events.append(gevent.spawn(proxy.get_all_network_events,
                                            user_address=user_address,
                                            from_block=from_block))
-        gevent.joinall(events, timeout=5)
-        flattened_events = list(itertools.chain.from_iterable([event.value for event in events]))
+        finished_greenlets = gevent.joinall(events, raise_error=True, timeout=20)
+        flattened_events = list(itertools.chain.from_iterable([gr.value for gr in finished_greenlets]))
         return UserCurrencyNetworkEventSchema().dump(flattened_events, many=True).data
 
 


### PR DESCRIPTION
We did run into errors on the production server. Some of the calls to get events
did timeout, and we ran into errors because the code didn't handle that case.

gevent.joinall returns the list of finished greenlets, but most of the code
tried to collect results from all of the greenlets.