### PR TITLE
Use configurable timeouts in api

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   },
   "syncInterval": 300,
   "updateNetworksInterval": 120,
+  "eventQueryTimeout": 20,
   "enableEtherFaucet": false
 }

--- a/relay/concurrency_utils.py
+++ b/relay/concurrency_utils.py
@@ -1,0 +1,28 @@
+from typing import Callable, List, Any, Iterable
+
+import gevent
+
+
+class TimeoutException(Exception):
+    """Exception to signal that the job could not be finished in time"""
+    pass
+
+
+def joinall(functions: Iterable[Callable], timeout: float = None) -> List[Any]:
+    """
+    Executes functions by spawning gevent greenlets and waiting for them
+    to finish up to `timeout` seconds.
+    If timing out, a TimeoutException is thrown
+    Args:
+        functions: The functions to execute each in a greenlet
+        timeout: Seconds to wait until timing out
+
+    Returns: The results of the executed functions
+
+    """
+    spawned_greenlets = [gevent.spawn(fun) for fun in functions]
+    finished_greenlets = gevent.joinall(greenlets=spawned_greenlets, timeout=timeout, raise_error=True)
+    if len(finished_greenlets) < len(spawned_greenlets):
+        raise TimeoutException('Could not finish all jobs before the timeout')
+
+    return [g.value for g in spawned_greenlets if g.value is not None]  # Use spawned greenlets to preserve order

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -50,6 +50,10 @@ class TrustlinesRelay:
     def enable_ether_faucet(self) -> bool:
         return self.config.get('enableEtherFaucet', False)
 
+    @property
+    def event_query_timeout(self) -> int:
+        return self.config.get('eventQueryTimeout', 20)
+
     def is_currency_network(self, address: str) -> bool:
         return address in self.networks
 

--- a/tests/unit/test_concurrency_utils.py
+++ b/tests/unit/test_concurrency_utils.py
@@ -1,0 +1,66 @@
+import pytest
+import gevent
+
+from relay.concurrency_utils import joinall, TimeoutException
+
+
+def test_success():
+    def f():
+        return 3
+
+    def g():
+        return 4
+
+    def h():
+        return 5
+
+    result = joinall([f, g, h], timeout=1.)
+
+    assert result == [3, 4, 5]
+
+
+def test_timeout():
+    def f():
+        return 3
+
+    def g():
+        gevent.sleep(5.)
+        return 4
+
+    def h():
+        return 5
+
+    with pytest.raises(TimeoutException):
+        joinall([f, g, h], timeout=1.)
+
+
+def test_timeout_not_enough():
+    def f():
+        return 3
+
+    def g():
+        gevent.sleep(5.)
+        return 4
+
+    def h():
+        gevent.sleep(5.)
+        return 5
+
+    with pytest.raises(TimeoutException):
+        joinall([f, g, h], timeout=1.)
+
+
+def test_no_timeout():
+    def f():
+        return 3
+
+    def g():
+        gevent.sleep(0.5)
+        return 4
+
+    def h():
+        return 5
+
+    result = joinall([f, g, h])
+
+    assert result == [3, 4, 5]


### PR DESCRIPTION
Add timeout as a config parameter
Add a concurrency joinall helper to make that functionality easy accessable
Check timeout only in outer most call in api
Instead of returning half of the events, return a timeout code. 