### PR TITLE
Added functions to find max capacity path between source and target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,5 @@ repos:
       exclude: .bumpversion.cfg
     - id: flake8
       language_version: python3.6
-      additional_dependencies: ["flake8-invalid-escape-sequences", "flake8-pep3101", "flake8-string-format", "flake8-per-file-ignores"]
+      additional_dependencies: ["flake8-invalid-escape-sequences", "flake8-string-format", "flake8-per-file-ignores"]
     - id: trailing-whitespace

--- a/constraints.txt
+++ b/constraints.txt
@@ -24,7 +24,6 @@ ethereum==1.6.1
 firebase-admin==2.11.0
 flake8==3.5.0
 flake8-invalid-escape-sequences==1.3
-flake8-pep3101==1.2.1
 flake8-per-file-ignores==0.6
 flake8-string-format==0.2.3
 Flask==0.12.2

--- a/relay/network_graph/dijkstra_weighted.py
+++ b/relay/network_graph/dijkstra_weighted.py
@@ -2,10 +2,11 @@ from heapq import heappush, heappop
 from itertools import count
 
 import networkx as nx
+import math
 
 
 def find_path(G, source, target, get_fee, value, max_hops=None, max_fees=None, ignore=None):
-    G_succ = G.succ if G.is_directed() else G.adj
+    G_adj = G.adj
 
     paths = {source: [source]}  # dictionary of paths
 
@@ -28,7 +29,7 @@ def find_path(G, source, target, get_fee, value, max_hops=None, max_fees=None, i
         if v == target:
             break
 
-        for u, e in G_succ[v].items():
+        for u, e in G_adj[v].items():
             cost = get_fee(v, u, e, d)  # fee of transferring from u to v
             if cost is None:
                 continue
@@ -55,13 +56,19 @@ def find_path(G, source, target, get_fee, value, max_hops=None, max_fees=None, i
 
 
 def find_maximum_capacity_path(G, source, target, max_hops=None):
-    G_succ = G.succ if G.is_directed() else G.adj
+    """
+    The logic is the same as dijkstra's Algorithm
+    We visit nodes with the maximum capacity untill we reach the destination.
+    At this point we are sure it is the maximum capacity path since every path
+    already have a smaller capacity and the capacity can only decrease.
+    """
+    G_adj = G.adj
     push = heappush
     pop = heappop
 
     paths = {source: [source]}  # dictionary of paths
     capacity = {}  # dictionary of capacities
-    seen = {source: 0}  # final dictionnaries of capacities
+    seen = {}  # final dictionnaries of capacities
     c = count()
     fringe = []  # use heapq with (distance,label) tuples
 
@@ -70,12 +77,10 @@ def find_maximum_capacity_path(G, source, target, max_hops=None):
             return data['creditline_ba'] + data['balance_ab']
         return data['creditline_ab'] - data['balance_ab']
 
-    for v, e in G_succ[source].items():
-        capacity[v] = get_capacity(source, v, e)
-        paths[v] = [source] + [v]
-        seen[source] = 0
-        push(fringe, (-capacity[v], next(c), v, 1))  # (-capacity, counter, node, hops)
-        # We use -capacity because we want the vertex with max capacity
+    capacity[source] = math.inf
+    paths[source] = [source]
+    push(fringe, (-math.inf, next(c), source, 0))  # (-capacity, counter, node, hops)
+    # We use -capacity because we want the vertex with max capacity
 
     while fringe:
         (capa, _, u, n) = pop(fringe)
@@ -86,26 +91,34 @@ def find_maximum_capacity_path(G, source, target, max_hops=None):
         if u == target:
             break
 
-        for v, e in G_succ[u].items():
+        for v, e in G_adj[u].items():
             if v in seen:
                 continue
             if max_hops is not None:
                 if n+1 > max_hops:
                     continue
             else:
-                min_cap = min(capacity[u], get_capacity(u, v, e))  # does not work with source
-                if v in capacity:
-                    if capacity[v] < min_cap:
-                        capacity[v] = min_cap
-                        paths[v] = paths[u]+[v]
-                        push(fringe, (-capacity[v], next(c), v, n+1))
-                else:
+                min_cap = min(capacity[u], get_capacity(u, v, e))
+                if (v not in capacity) or (v in capacity and capacity[v] < min_cap):
                     capacity[v] = min_cap
                     paths[v] = paths[u]+[v]
                     push(fringe, (-capacity[v], next(c), v, n+1))
 
     try:
-        return (seen[target], paths[target])  # first element is the total capacity of the path not transferable amount
+        capacities = []
+        u = source
+
+        for v in paths[target][1:]:
+            if u < v:
+                capacity = get_capacity(u, v, G[u][v])
+            else:
+                capacity = get_capacity(u, v, G[v][u])
+
+            capacities.append(capacity)
+            u = v
+
+        return (seen[target], paths[target], capacities)
+        # first element is the total capacity of the path not transferable amount
     except KeyError:
         raise nx.NetworkXNoPath(
             "node %s not reachable from %s" % (source, target))
@@ -144,8 +157,8 @@ def find_path_triangulation(G, source, target_reduce, target_increase, get_fee, 
         raise nx.NetworkXNoPath(
             "The balance of target_reduce is lower than value %d" % value)
 
-    G_succ = G.succ if G.is_directed() else G.adj
-    neighbors = [x[0] for x in G_succ[source].items()]
+    G_adj = G.adj
+    neighbors = [x[0] for x in G_adj[source].items()]
 
     if target_reduce not in neighbors:
         raise nx.NetworkXNoPath(

--- a/relay/network_graph/fees.py
+++ b/relay/network_graph/fees.py
@@ -1,5 +1,3 @@
-
-
 def imbalance_fee(factor, pre_balance, value):
     if factor == 0:
         return 0
@@ -14,3 +12,28 @@ def imbalance_fee(factor, pre_balance, value):
 def new_balance(factor, pre_balance, value):
     fee = imbalance_fee(factor, pre_balance, value)
     return pre_balance - value - fee
+
+
+def estimate_fees_from_capacity(factor, capacity, hops, previous_hops_value=0):
+        """
+        Gives an upper bound on the fees for a max capacity transfer with n hops
+        The "imbalance_fee" function not being bijective, only an estimate of the fees can be found from "value + fee"
+        uses recursion to find the closest estimate
+
+        Args:
+            factor: the divisor used to calculate imbalance fees (not actually a factor)
+            capacity: the maximum capacity of a path
+            hops: the number of hops in the path
+            previous_hops_value: the value of the fees for the previous hop
+
+        Returns:
+            returns the value of the fees
+        """
+        if factor == 0:
+            return 0
+
+        if hops == 1:
+            return (capacity + previous_hops_value)//factor + 1 + previous_hops_value
+        else:
+            return estimate_fees_from_capacity(factor, capacity, hops-1, previous_hops_value + 1 +
+                                               (capacity + previous_hops_value)//factor)

--- a/relay/network_graph/fees.py
+++ b/relay/network_graph/fees.py
@@ -1,39 +1,41 @@
-def imbalance_fee(factor, pre_balance, value):
-    if factor == 0:
+def imbalance_fee(divisor, pre_balance, value):
+    if divisor == 0:
         return 0
     imbalance_generated = value
     if pre_balance > 0:
         imbalance_generated = value - pre_balance
         if imbalance_generated <= 0:
             return 0
-    return (imbalance_generated // factor) + 1  # minimum fee is 1
+    return (imbalance_generated // divisor) + 1  # minimum fee is 1
 
 
-def new_balance(factor, pre_balance, value):
-    fee = imbalance_fee(factor, pre_balance, value)
+def new_balance(divisor, pre_balance, value):
+    fee = imbalance_fee(divisor, pre_balance, value)
     return pre_balance - value - fee
 
 
-def estimate_fees_from_capacity(factor, capacity, hops, previous_hops_value=0):
+def estimate_fees_from_capacity(divisor, min_capacity, path_capacities):
         """
-        Gives an upper bound on the fees for a max capacity transfer with n hops
+        Gives an upper bound on the fees for a max capacity transfer
         The "imbalance_fee" function not being bijective, only an estimate of the fees can be found from "value + fee"
-        uses recursion to find the closest estimate
+        Now I actually believe I find the exact value / the best estimate.
 
         Args:
-            factor: the divisor used to calculate imbalance fees (not actually a factor)
-            capacity: the maximum capacity of a path
-            hops: the number of hops in the path
-            previous_hops_value: the value of the fees for the previous hop
+            divisor: the divisor used to calculate imbalance fees
+            min_capacity: the maximum capacity of a path (the minimum capacity of path_capacities)
+            path_capacities: a list of the (ordered) capacities of the vertices along the path
 
         Returns:
             returns the value of the fees
         """
-        if factor == 0:
+
+        if divisor == 0:
             return 0
 
-        if hops == 1:
-            return (capacity + previous_hops_value)//factor + 1 + previous_hops_value
-        else:
-            return estimate_fees_from_capacity(factor, capacity, hops-1, previous_hops_value + 1 +
-                                               (capacity + previous_hops_value)//factor)
+        hops = len(path_capacities)
+        fees = 0
+        for i in range(hops):
+            capacity = min(path_capacities[i], min_capacity+fees)
+            fees += int((1+capacity/divisor)/(1+1/divisor))
+
+        return fees

--- a/relay/network_graph/graph.py
+++ b/relay/network_graph/graph.py
@@ -387,8 +387,13 @@ class CurrencyNetworkGraph(object):
 
         fees = estimate_fees_from_capacity(self.capacity_imbalance_fee_divisor, capacity, path_capacities)
 
-        # we treat the edge case that bothers us so much here.
-        if capacity//divisor == capacity % divisor:
+        """
+        we want to withdraw 1 from the capacity if we are on the discontinuity of 'floor(capacity - fees // divisor)':
+        (capacity - fees) % divisor == 0
+        and this is discontinuity happens around the minimal capacity of the path and due to high fees elswhere:
+        capacity = n * divisor + n  <=> capacity//divisor == (capacity % divisor)
+        """
+        if capacity//divisor == (capacity % divisor) and (capacity - fees) % divisor == 0:
             capacity -= 1
 
         return capacity - fees

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ psycogreen
 
 # --- development dependencies, i.e. dependencies not needed for running tl-relay
 flake8
-flake8-pep3101
 flake8-string-format
 flake8-invalid-escape-sequences
 flake8-per-file-ignores

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ ignore =
        # default:
        E121,E123,E126,E226,E24,E704,W503,W504
 
-per-file-ignores =.
-    # ignore % formatter in dijkstra_weighted.py
-    dijkstra_weighted.py: S001

--- a/tests/unit/test_fees.py
+++ b/tests/unit/test_fees.py
@@ -1,4 +1,4 @@
-from relay.network_graph.fees import imbalance_fee, new_balance
+from relay.network_graph.fees import imbalance_fee, new_balance, estimate_fees_from_capacity
 
 
 def test_increase_imbalance_fee():
@@ -39,3 +39,40 @@ def test_new_balance_both():
 
 def test_new_balance_from_negative():
     assert new_balance(50, -250, 250) == -506
+
+
+def test_estimate_fees_from_capacity_single_hop():
+    """
+    Tests the estimation for a single hop
+    The estimation has to be an upper bound so the actual fees have to be lower
+    """
+    fees = estimate_fees_from_capacity(100, 12345, 1)
+    assert fees >= imbalance_fee(100, 0, 12345-fees)
+
+
+def test_estimate_fees_from_capacity_single_hop_edge_case():
+    """Tests the edge case for the estimation"""
+    fees = estimate_fees_from_capacity(100, 101, 1)
+    assert fees >= imbalance_fee(100, 0, 101-fees)
+    assert fees == 2
+
+
+def test_estimate_fees_from_capacity_single_hop_sanity():
+    """Tests whether for small values outside of indeterminate case, the estimation is exact"""
+    fees = estimate_fees_from_capacity(100, 150, 1)
+    assert fees == imbalance_fee(100, 0, 150-fees)
+
+
+def test_estimate_fees_from_capacity_two_hops():
+    fees = estimate_fees_from_capacity(100, 104, 2)
+    assert fees >= 4
+
+
+def test_estimate_fees_from_capacity_three_hops():
+    fees = estimate_fees_from_capacity(100, 106, 3)
+    assert fees >= 6
+
+
+def test_estimate_fees_from_capacity_eight_hops():
+    fees = estimate_fees_from_capacity(100, 116, 8)
+    assert fees >= 16

--- a/tests/unit/test_fees.py
+++ b/tests/unit/test_fees.py
@@ -50,11 +50,18 @@ def test_estimate_fees_from_capacity_single_hop():
     assert fees >= imbalance_fee(100, 0, 12345-fees)
 
 
-def test_estimate_fees_from_capacity_single_hop_edge_case():
-    """Tests the edge case for the estimation"""
+def test_estimate_fees_from_capacity_single_hop_upper_edge_case():
+    """Tests the upper value of the edge case for the estimation"""
     fees = estimate_fees_from_capacity(100, 101, 1)
     assert fees >= imbalance_fee(100, 0, 101-fees)
     assert fees == 2
+
+
+def test_estimate_fees_from_capacity_single_hop_lower_edge_case():
+    """Tests the lower value of the edge case for the estimation"""
+    fees = estimate_fees_from_capacity(100, 100, 1)
+    assert fees >= imbalance_fee(100, 0, 100-fees)
+    assert fees == 1
 
 
 def test_estimate_fees_from_capacity_single_hop_sanity():

--- a/tests/unit/test_fees.py
+++ b/tests/unit/test_fees.py
@@ -46,40 +46,43 @@ def test_estimate_fees_from_capacity_single_hop():
     Tests the estimation for a single hop
     The estimation has to be an upper bound so the actual fees have to be lower
     """
-    fees = estimate_fees_from_capacity(100, 12345, 1)
-    assert fees >= imbalance_fee(100, 0, 12345-fees)
+    fees = estimate_fees_from_capacity(100, 12345, [12345])
+    assert fees == 123
 
 
 def test_estimate_fees_from_capacity_single_hop_upper_edge_case():
     """Tests the upper value of the edge case for the estimation"""
-    fees = estimate_fees_from_capacity(100, 101, 1)
-    assert fees >= imbalance_fee(100, 0, 101-fees)
-    assert fees == 2
+    fees = estimate_fees_from_capacity(100, 101, [101])
+    assert fees == 1
 
 
 def test_estimate_fees_from_capacity_single_hop_lower_edge_case():
     """Tests the lower value of the edge case for the estimation"""
-    fees = estimate_fees_from_capacity(100, 100, 1)
-    assert fees >= imbalance_fee(100, 0, 100-fees)
+    fees = estimate_fees_from_capacity(100, 100, [100])
     assert fees == 1
 
 
 def test_estimate_fees_from_capacity_single_hop_sanity():
     """Tests whether for small values outside of indeterminate case, the estimation is exact"""
-    fees = estimate_fees_from_capacity(100, 150, 1)
-    assert fees == imbalance_fee(100, 0, 150-fees)
+    fees = estimate_fees_from_capacity(100, 150, [150])
+    assert fees == 2
 
 
-def test_estimate_fees_from_capacity_two_hops():
-    fees = estimate_fees_from_capacity(100, 104, 2)
+def test_estimate_fees_from_capacity_last_hop_smallest():
+    fees = estimate_fees_from_capacity(100, 104, [500, 104])
+    assert fees >= 4
+
+
+def test_estimate_fees_from_capacity_first_hop_smallest():
+    fees = estimate_fees_from_capacity(100, 104, [104, 500])
     assert fees >= 4
 
 
 def test_estimate_fees_from_capacity_three_hops():
-    fees = estimate_fees_from_capacity(100, 106, 3)
+    fees = estimate_fees_from_capacity(100, 106, [112, 106, 250])
     assert fees >= 6
 
 
 def test_estimate_fees_from_capacity_eight_hops():
-    fees = estimate_fees_from_capacity(100, 116, 8)
+    fees = estimate_fees_from_capacity(100, 116, [116, 116, 116, 116, 116, 116, 116, 116])
     assert fees >= 16

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -249,6 +249,22 @@ def test_capacity_path_single_hop(complex_community_with_trustlines):
     assert value == 50000
 
 
+def test_capacity_path_single_hop_with_fees(complex_community_with_trustlines_and_fees):
+    """test for getting the capacity of the path A-B"""
+    value, path = complex_community_with_trustlines_and_fees.find_maximum_capacity_path(
+                A, B)
+    assert path == [A, B]
+    assert value == 49504
+
+
+def test_capacity_path_multi_hop_with_fees(complex_community_with_trustlines_and_fees):
+    """test for getting the capacity of the path B-E"""
+    value, path = complex_community_with_trustlines_and_fees.find_maximum_capacity_path(
+                B, E)
+    assert path == [B, D, E]
+    assert 49008 <= value <= 49013
+
+
 def test_capacity_path_single_hop_more_capacity(complex_community_with_trustlines):
     """test whether the balance A-B impacts capacity"""
     complex_community_with_trustlines.update_balance(A, B, 10000)

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -77,6 +77,20 @@ def complex_community_with_trustlines_and_fees(complexfriendsdict):
 
 
 @pytest.fixture
+def complex_community_with_trustlines_and_fees_33(complexfriendsdict):
+    community = CurrencyNetworkGraph(33)
+    community.gen_network(complexfriendsdict)
+    return community
+
+
+@pytest.fixture
+def complex_community_with_trustlines_and_fees_202(complexfriendsdict):
+    community = CurrencyNetworkGraph(202)
+    community.gen_network(complexfriendsdict)
+    return community
+
+
+@pytest.fixture
 def complex_community_with_trustlines(complexfriendsdict):
     community = CurrencyNetworkGraph()
     community.gen_network(complexfriendsdict)
@@ -321,7 +335,7 @@ def test_capacity_path_multi_hops_positive_balance(complex_community_with_trustl
 
 
 def test_max_capacity_estimation_single_hop(complex_community_with_trustlines_and_fees):
-    """Tests whether the path and capacity found actually work (= estimation of fees is bigger than actual fees)"""
+    """Tests whether the path and capacity found actually work"""
     complex_community_with_trustlines_and_fees.update_balance(A, B, -49899)
     complex_community_with_trustlines_and_fees.update_balance(A, C, -50000)
 
@@ -332,8 +346,19 @@ def test_max_capacity_estimation_single_hop(complex_community_with_trustlines_an
     assert path == [A, B]
 
 
+def test_max_capacity_estimation_single_hop_big_value(complex_community_with_trustlines_and_fees):
+    """Tests whether the path and capacity found actually work"""
+    complex_community_with_trustlines_and_fees.update_balance(A, B, -50000+12345)
+    complex_community_with_trustlines_and_fees.update_balance(A, C, -50000)
+    capacity, path = complex_community_with_trustlines_and_fees.find_maximum_capacity_path(
+                A, B)
+
+    value, path = complex_community_with_trustlines_and_fees.find_path(A, B, capacity)
+    assert path == [A, B]
+
+
 def test_max_capacity_estimation_multi_hop(complex_community_with_trustlines_and_fees):
-    """Tests whether the path and capacity found actually work (= estimation of fees is bigger than actual fees)"""
+    """Tests whether the path and capacity found actually work"""
     complex_community_with_trustlines_and_fees.update_balance(A, C, 10000)
     complex_community_with_trustlines_and_fees.update_balance(C, D, 10000)
 
@@ -342,6 +367,28 @@ def test_max_capacity_estimation_multi_hop(complex_community_with_trustlines_and
 
     value, path = complex_community_with_trustlines_and_fees.find_path(A, E, capacity)
     assert path == [A, C, D, E]
+
+
+def test_max_capacity_estimation_multi_hop_fees_33(complex_community_with_trustlines_and_fees_33):
+    """Tests whether the path and capacity found actually work with different fee divisor"""
+    complex_community_with_trustlines_and_fees_33.update_balance(A, B, -50000+12345)
+    complex_community_with_trustlines_and_fees_33.update_balance(A, C, -50000)
+    capacity, path = complex_community_with_trustlines_and_fees_33.find_maximum_capacity_path(
+                A, B)
+
+    value, path = complex_community_with_trustlines_and_fees_33.find_path(A, B, capacity)
+    assert path == [A, B]
+
+
+def test_max_capacity_estimation_multi_hop_fees_202(complex_community_with_trustlines_and_fees_202):
+    """Tests whether the path and capacity found actually work with higher fee divisor"""
+    complex_community_with_trustlines_and_fees_202.update_balance(A, B, -50000+12345)
+    complex_community_with_trustlines_and_fees_202.update_balance(A, C, -50000)
+    capacity, path = complex_community_with_trustlines_and_fees_202.find_maximum_capacity_path(
+                A, B)
+
+    value, path = complex_community_with_trustlines_and_fees_202.find_path(A, B, capacity)
+    assert path == [A, B]
 
 
 def test_mediated_transfer(community_with_trustlines):


### PR DESCRIPTION
https://github.com/trustlines-network/relay/issues/34

I added the function to find the max capacity path in dijkstra_weighted.py

I added the function to estimate the fees from the max capacity and the number of hops in fees.py, because I believe that is where it fits the most, and it would have to be changed if we change anything about the fees.

I added tests for the fee estimation in test_fees and tests for the path/capacity in graph.py

I later added tests showing that the max capacity path we found is actually usable in graph.py, these tests should fail in case someone comes to modify the fees without modifying the function to estimate the fees from the max capacity.