### PR TITLE
install and use some useful flake8 plugins

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,6 +3,8 @@ anyconfig==0.9.4
 argh==0.26.2
 attrs==17.4.0
 bitcoin==1.1.42
+CacheControl==0.12.5
+cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
@@ -21,6 +23,10 @@ eth-utils==0.7.4
 ethereum==1.6.1
 firebase-admin==2.11.0
 flake8==3.5.0
+flake8-invalid-escape-sequences==1.3
+flake8-pep3101==1.2.1
+flake8-per-file-ignores==0.6
+flake8-string-format==0.2.3
 Flask==0.12.2
 Flask-Cors==3.0.3
 Flask-RESTful==0.3.6
@@ -50,6 +56,7 @@ mccabe==0.6.1
 msgpack==0.5.6
 mypy==0.590
 networkx==2.1
+pathmatch==0.2.1
 pathtools==0.1.2
 pbkdf2==1.3
 pkg-resources==0.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ pygraphviz
 pysha3
 pytest==3.2.5
 flake8
+flake8-pep3101
+flake8-string-format
+flake8-invalid-escape-sequences
+flake8-per-file-ignores
 coverage
 eth-testrpc
 git+https://github.com/trustlines-network/contracts.git@develop

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [flake8]
 max-line-length = 119
+ignore =
+       # P101 format string does contain unindexed parameters
+      P101
+       # default:
+       E121,E123,E126,E226,E24,E704,W503,W504
+
+per-file-ignores =.
+    # ignore % formatter in dijkstra_weighted.py
+    dijkstra_weighted.py: S001


### PR DESCRIPTION
We install the following flake8 plugins:

- flake8-pep3101: warn about % formatting
- flake8-string-format: warn about errors in .format calls
- flake8-invalid-escape-sequences: warn about invalid escape sequences in
  strings

and flake8-per-file-ignores in order to ignore warnings about % formatting in
one of our source files. flake8 automatically uses those plugins.

These should be pretty uncontroversial.

There are more useful plugins, but they either need work from our side to fix
things or need some discussion.