### PR TITLE
Feature/clienttokendb

### DIFF
--- a/relay/pushservice/client_token_db.py
+++ b/relay/pushservice/client_token_db.py
@@ -34,8 +34,8 @@ class ClientTokenDB:
         self.session = Session()
 
     def get_client_tokens(self, user_address: str) -> Iterable[str]:
-        return [token_mapping_orm.client_token for token_mapping_orm in (self.session.query(TokenMappingORM)
-                .filter(TokenMappingORM.user_address == user_address).all())]
+        return [client_token for (client_token,) in self.session.query(TokenMappingORM.client_token)
+                .filter(TokenMappingORM.user_address == user_address).all()]
 
     def get_all_client_tokens(self) -> Iterable[TokenMapping]:
         return [TokenMapping(token_mapping_orm.user_address, token_mapping_orm.client_token) for token_mapping_orm in

--- a/relay/pushservice/client_token_db.py
+++ b/relay/pushservice/client_token_db.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+from collections import namedtuple
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String
@@ -22,6 +23,9 @@ class ClientTokenAlreadyExistsException(ClientTokenDBException):
     pass
 
 
+TokenMapping = namedtuple('TokenMapping', ['user_address', 'client_token'])
+
+
 class ClientTokenDB:
 
     def __init__(self, engine) -> None:
@@ -32,6 +36,10 @@ class ClientTokenDB:
     def get_client_tokens(self, user_address: str) -> Iterable[str]:
         return [token_mapping_orm.client_token for token_mapping_orm in (self.session.query(TokenMappingORM)
                 .filter(TokenMappingORM.user_address == user_address).all())]
+
+    def get_all_client_tokens(self) -> Iterable[TokenMapping]:
+        return [TokenMapping(token_mapping_orm.user_address, token_mapping_orm.client_token) for token_mapping_orm in
+                (self.session.query(TokenMappingORM).all())]
 
     def add_client_token(self, user_address: str, client_token: str) -> None:
         """

--- a/tests/unit/pushnotifications/test_client_token_db.py
+++ b/tests/unit/pushnotifications/test_client_token_db.py
@@ -33,3 +33,24 @@ def test_delete_token(client_token_db: ClientTokenDB):
     client_token_db.add_client_token('0x123', 'token')
     client_token_db.delete_client_token('0x123', 'token')
     assert client_token_db.get_client_tokens('0x123') == []
+
+
+def test_delete_non_existent_token(client_token_db: ClientTokenDB):
+    client_token_db.delete_client_token('0x123', 'token')
+    assert client_token_db.get_client_tokens('0x123') == []
+
+
+def test_get_client_tokens(client_token_db: ClientTokenDB):
+    client_token_db.add_client_token('0x123', 'token1')
+    client_token_db.add_client_token('0x124', 'token2')
+    client_token_db.add_client_token('0x125', 'token3')
+    assert client_token_db.get_client_tokens('0x124') == ['token2']
+
+
+def test_all_tokens(client_token_db: ClientTokenDB):
+    client_token_db.add_client_token('0x123', 'token1')
+    client_token_db.add_client_token('0x124', 'token2')
+    client_token_db.add_client_token('0x125', 'token3')
+    assert set(client_token_db.get_all_client_tokens()) == {('0x123', 'token1'),
+                                                            ('0x124', 'token2'),
+                                                            ('0x125', 'token3')}

--- a/tests/unit/pushnotifications/test_client_token_db.py
+++ b/tests/unit/pushnotifications/test_client_token_db.py
@@ -1,0 +1,35 @@
+import pytest
+
+from sqlalchemy import create_engine
+
+from relay.pushservice.client_token_db import ClientTokenDB, ClientTokenAlreadyExistsException
+
+
+@pytest.fixture()
+def client_token_db():
+    return ClientTokenDB(create_engine('sqlite:///:memory:'))
+
+
+def test_add_client_token(client_token_db: ClientTokenDB):
+    client_token_db.add_client_token('0x123', 'token')
+    assert client_token_db.get_client_tokens('0x123') == ['token']
+
+
+def test_add_multiple_client_token(client_token_db: ClientTokenDB):
+    client_token_db.add_client_token('0x123', 'token1')
+    client_token_db.add_client_token('0x123', 'token2')
+    client_token_db.add_client_token('0x123', 'token3')
+    assert set(client_token_db.get_client_tokens('0x123')) == {'token1', 'token2', 'token3'}
+
+
+def test_cannot_add_same_token_twice(client_token_db: ClientTokenDB):
+    client_token_db.add_client_token('0x123', 'token')
+    with pytest.raises(ClientTokenAlreadyExistsException):
+        client_token_db.add_client_token('0x123', 'token')
+    assert client_token_db.get_client_tokens('0x123') == ['token']
+
+
+def test_delete_token(client_token_db: ClientTokenDB):
+    client_token_db.add_client_token('0x123', 'token')
+    client_token_db.delete_client_token('0x123', 'token')
+    assert client_token_db.get_client_tokens('0x123') == []


### PR DESCRIPTION
- Add simple database for client tokens
- Use database to store client tokens
   - on start use database to start sending push notifications to stored client tokens
   - store the client tokens for now in a sqlight file db. can be switched to postgresql later
   - update client tokens when new client token is added or deleted

Closes #109 