### PR TITLE
Fix a race condition bug in stream unsubscribe

### DIFF
--- a/relay/streams.py
+++ b/relay/streams.py
@@ -71,8 +71,9 @@ class Subscription():
         return False
 
     def unsubscribe(self) -> None:
-        self.closed = True
-        self.subject.unsubscribe(self)
+        if not self.closed:
+            self.closed = True
+            self.subject.unsubscribe(self)
 
 
 class MessagingSubject(Subject):


### PR DESCRIPTION
When inside notify calling client.send a client can unschedule the greenlet and thus delay unsubscription
inside of notify. This means it can be already unsubscribed and we have to handle that