### PR TITLE
synchronize dependencies in setup.py and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,6 @@ ethereum==1.6.1
 networkx>=2.0
 pygraphviz
 pysha3
-pytest==3.2.5
-flake8
-flake8-pep3101
-flake8-string-format
-flake8-invalid-escape-sequences
-flake8-per-file-ignores
-coverage
-eth-testrpc
 git+https://github.com/trustlines-network/contracts.git@develop
 sqlalchemy
 eth-utils==0.7.4
@@ -23,5 +15,15 @@ tinyrpc
 gevent-websocket
 marshmallow
 flask-sockets
-mypy
 firebase-admin
+
+# --- development dependencies, i.e. dependencies not needed for running tl-relay
+flake8
+flake8-pep3101
+flake8-string-format
+flake8-invalid-escape-sequences
+flake8-per-file-ignores
+coverage
+mypy
+pytest==3.2.5
+eth-testrpc

--- a/setup.py
+++ b/setup.py
@@ -85,12 +85,18 @@ setup(
                       'gevent==1.1.2',
                       'web3[gevent]',
                       'ethereum==1.6.1',
-                      'eth-utils',
                       'networkx>=2.0',
                       'pygraphviz',
                       'pysha3',
+                      'trustlines-contracts',
+                      'sqlalchemy',
+                      'eth-utils',
+                      'tinyrpc',
+                      'gevent-websocket',
+                      'marshmallow',
+                      'flask-sockets',
                       'firebase-admin'
-],
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Some dependencies had been missing in setup.py. Please not that setup.py depends
on trustlines-contracts, requirements.txt depends on git+https dependency for
that package. Installation of the former won't work, because the package doesn't
live on the public PyPI server.