### PR TITLE
add config file for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v0.9.1
+    hooks:
+    - id: check-added-large-files
+    - id: check-ast
+      language_version: python3.6
+    - id: check-byte-order-marker
+    - id: check-case-conflict
+    - id: check-json
+    - id: check-merge-conflict
+    - id: check-yaml
+    - id: debug-statements
+      language_version: python3.6
+    - id: end-of-file-fixer
+      exclude: .bumpversion.cfg
+    - id: flake8
+      language_version: python3.6
+      additional_dependencies: ["flake8-invalid-escape-sequences", "flake8-pep3101", "flake8-string-format", "flake8-per-file-ignores"]
+    - id: trailing-whitespace

--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -113,7 +113,7 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 
 ---
 
-### Users list in currency network 
+### Users list in currency network
 Returns a list of user addresses in a currency network.
 #### Request
 ```
@@ -140,7 +140,7 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 
 ---
 
-### User details in currency network 
+### User details in currency network
 Returns detailed information of an user in a currency network.
 #### Request
 ```
@@ -209,8 +209,8 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 		"balance": "-102",
 		"given": "10000",
 		"received": "10000",
-		"leftGiven": "10102", 
-		"leftReceived": "9898", 
+		"leftGiven": "10102",
+		"leftReceived": "9898",
 		"id": "0x314338891c370d4c77657386c676b6cd2e4862af1244820f9e7b9166d181057f"
 	}
 ]


### PR DESCRIPTION
pre-commit [1] is framework for managing git pre-commit hooks. Since I failed to
reformat files with black before committing them in the past, let's try
this. Please note that we don't have any hooks for black enabled at the moment.
But it will run flake8 and do some more useful checks.

After installation of pre-commit, this can be activated by running

  pre-commit install

also fix some things that it already complained about.

[1] https://pre-commit.com/