### PR TITLE
Return values as strings

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -14,7 +14,12 @@ from relay.blockchain.unw_eth_proxy import UnwEthProxy
 from relay.blockchain.unw_eth_events import UnwEthEvent
 from relay.blockchain.currency_network_events import CurrencyNetworkEvent
 from relay.api import fields as custom_fields
-from .schemas import CurrencyNetworkEventSchema, UserCurrencyNetworkEventSchema, UserTokenEventSchema
+from .schemas import (CurrencyNetworkEventSchema,
+                      UserCurrencyNetworkEventSchema,
+                      UserTokenEventSchema,
+                      AccountSummarySchema,
+                      TrustlineSchema,
+                      TxInfosSchema)
 from relay.relay import TrustlinesRelay
 from relay.concurrency_utils import TimeoutException
 from relay.logger import get_logger
@@ -80,7 +85,8 @@ class User(Resource):
 
     def get(self, network_address: str, user_address: str):
         abort_if_unknown_network(self.trustlines, network_address)
-        return self.trustlines.currency_network_graphs[network_address].get_account_sum(user_address).as_dict()
+        return AccountSummarySchema().dump(
+            self.trustlines.currency_network_graphs[network_address].get_account_sum(user_address)).data
 
 
 class ContactList(Resource):
@@ -93,27 +99,11 @@ class ContactList(Resource):
         return self.trustlines.currency_network_graphs[network_address].get_friends(user_address)
 
 
-class TrustlineDao(object):
-    def __init__(self, network_address: str, a_address: str, b_address: str, account_sum: str) -> None:
-        self.network_address = network_address
-        self.a_address = a_address
-        self.b_address = b_address
-        self.account_sum = account_sum
-
-    @property
-    def id(self):
-        if self.a_address < self.b_address:
-            return sha3(self.network_address + self.a_address + self.b_address)
+def _id(network_address, a_address, b_address):
+        if a_address < b_address:
+            return sha3(network_address + a_address + b_address)
         else:
-            return sha3(self.network_address + self.b_address + self.a_address)
-
-    def as_dict(self):
-        trustline = {
-            'address': self.b_address,
-            'id': self.id
-        }
-        trustline.update(self.account_sum.as_dict())
-        return trustline
+            return sha3(network_address + b_address + a_address)
 
 
 class Trustline(Resource):
@@ -124,8 +114,12 @@ class Trustline(Resource):
     def get(self, network_address, a_address, b_address):
         abort_if_unknown_network(self.trustlines, network_address)
         graph = self.trustlines.currency_network_graphs[network_address]
-        trustline = TrustlineDao(network_address, a_address, b_address, graph.get_account_sum(a_address, b_address))
-        return trustline.as_dict()
+        data = TrustlineSchema().dump(graph.get_account_sum(a_address, b_address)).data
+        data.update({
+            'address': b_address,
+            'id': _id(network_address, a_address, b_address)
+        })
+        return data
 
 
 class TrustlineList(Resource):
@@ -139,11 +133,14 @@ class TrustlineList(Resource):
         friends = graph.get_friends(user_address)
         accounts = []
         for friend_address in friends:
-            trustline = TrustlineDao(network_address,
-                                     user_address,
-                                     friend_address,
-                                     graph.get_account_sum(user_address, friend_address))
-            accounts.append(trustline.as_dict())
+            data = TrustlineSchema().dump(graph.get_account_sum(user_address, friend_address)).data
+            data.update(
+                {
+                    'address': friend_address,
+                    'id': _id(network_address, user_address, friend_address)
+                }
+            )
+            accounts.append(data)
         return accounts
 
 
@@ -280,7 +277,7 @@ class TransactionInfos(Resource):
         self.trustlines = trustlines
 
     def get(self, user_address: str):
-        return self.trustlines.node.get_tx_infos(user_address)
+        return TxInfosSchema().dump(self.trustlines.node.get_tx_infos(user_address)).data
 
 
 class Relay(Resource):
@@ -308,7 +305,7 @@ class Balance(Resource):
         self.trustlines = trustlines
 
     def get(self, user_address: str):
-        return self.trustlines.node.balance(user_address)
+        return str(self.trustlines.node.balance(user_address))
 
 
 class Block(Resource):

--- a/relay/api/schemas.py
+++ b/relay/api/schemas.py
@@ -43,3 +43,36 @@ class TokenEventSchema(BlockchainEventSchema):
 class UserTokenEventSchema(TokenEventSchema):
     direction = fields.Str()
     address = Address(attribute='other_party')
+
+
+class AccountSummarySchema(Schema):
+    class Meta:
+        strict = True
+
+    leftGiven = BigInteger(attribute='creditline_left_given')
+    leftReceived = BigInteger(attribute='creditline_left_received')
+    given = BigInteger(attribute='creditline_given')
+    received = BigInteger(attribute='creditline_received')
+    balance = BigInteger()
+
+
+class TrustlineSchema(Schema):
+    class Meta:
+        strict = True
+
+    leftGiven = BigInteger(attribute='creditline_left_given')
+    leftReceived = BigInteger(attribute='creditline_left_received')
+    given = BigInteger(attribute='creditline_given')
+    received = BigInteger(attribute='creditline_received')
+    balance = BigInteger()
+    id = fields.Str()
+    address = Address(attribute='other_party')
+
+
+class TxInfosSchema(Schema):
+    class Meta:
+        strict = True
+
+    balance = BigInteger()
+    nonce = fields.Integer()
+    gasPrice = BigInteger(attribute='gas_price')

--- a/relay/blockchain/node.py
+++ b/relay/blockchain/node.py
@@ -1,3 +1,8 @@
+from collections import namedtuple
+
+
+TxInfos = namedtuple('TxInfos', 'balance, nonce, gas_price')
+
 
 class Node:
 
@@ -11,9 +16,9 @@ class Node:
         return self._web3.eth.getTransactionReceipt(txn_hash)
 
     def get_tx_infos(self, user_address):
-        return {'balance': self._web3.eth.getBalance(user_address),
-                'nonce': self._web3.eth.getTransactionCount(user_address),
-                'gasPrice': self._web3.eth.gasPrice}
+        return TxInfos(balance=self._web3.eth.getBalance(user_address),
+                       nonce=self._web3.eth.getTransactionCount(user_address),
+                       gas_price=self._web3.eth.gasPrice)
 
     @property
     def blocknumber(self):

--- a/relay/network_graph/graph.py
+++ b/relay/network_graph/graph.py
@@ -146,13 +146,6 @@ class AccountSummary(object):
     def creditline_left_received(self):
         return self.balance + self.creditline_received
 
-    def as_dict(self):
-        return {'balance': self.balance,
-                'given': self.creditline_given,
-                'received': self.creditline_received,
-                'leftGiven': self.creditline_left_given,
-                'leftReceived': self.creditline_left_received}
-
 
 class CurrencyNetworkGraph(object):
     """The whole graph of a Token Network"""


### PR DESCRIPTION
Fixes #98
This also changes the txinfo endpoint. Balance is now returned as string and gasPrice also as string. 
nonce is still an Integer. 
@dakingha69 can you take a look what needs to change in the clientlib?
Also is it right to return it as strings in decimal format? What is the current most used variant in the ecospace. Hex encoded or decimal?
