### PR TITLE
Change "tx-infos" to "txinfos" in api doc

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -688,15 +688,15 @@ Following additional attributes for `Transfer` events:
 
 ---
 
-### Transaction infos of user
+### Transaction infos for user
 Returns information that is needed to sign a transaction.
 #### Request
 ```
-GET /users/:userAddress/tx-infos
+GET /users/:userAddress/txinfos
 ```
 #### Example Request
 ```
-curl https://relay0.testnet.trustlines.network/api/v1/users/0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce/tx-infos
+curl https://relay0.testnet.trustlines.network/api/v1/users/0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce/txinfos
 ```
 #### URL Parameters
 |Name|Type|Required|Description|


### PR DESCRIPTION
I would guess the implementation of the API does not match the documentation for "Transaction infos of user". The doc states "GET /users/:userAddress/tx-infos" while it is actually '/users/<address:user_address>/txinfos'.

https://github.com/trustlines-network/relay/blob/develop/relay/api/app.py#L65

See also: https://github.com/trustlines-network/clientlib/blob/develop/src/Transaction.ts#L140