### PR TITLE
Include users own address in events

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -29,7 +29,7 @@ Flask==1.0.2
 Flask-Cors==3.0.6
 Flask-RESTful==0.3.6
 Flask-Sockets==0.2.1
-gevent==1.3.5
+gevent==1.1.2
 gevent-websocket==0.10.1
 geventhttpclient==1.3.1
 google-api-core==1.2.1

--- a/relay/api/schemas.py
+++ b/relay/api/schemas.py
@@ -30,7 +30,8 @@ class CurrencyNetworkEventSchema(BlockchainEventSchema):
 
 class UserCurrencyNetworkEventSchema(CurrencyNetworkEventSchema):
     direction = fields.Str()
-    address = Address(attribute='other_party')
+    counterParty = Address(attribute='counter_party')
+    user = Address()
 
 
 class TokenEventSchema(BlockchainEventSchema):
@@ -42,7 +43,8 @@ class TokenEventSchema(BlockchainEventSchema):
 
 class UserTokenEventSchema(TokenEventSchema):
     direction = fields.Str()
-    address = Address(attribute='other_party')
+    counterParty = Address(attribute='counter_party')
+    user = Address()
 
 
 class ExchangeEventSchema(BlockchainEventSchema):

--- a/relay/api/schemas.py
+++ b/relay/api/schemas.py
@@ -30,6 +30,7 @@ class CurrencyNetworkEventSchema(BlockchainEventSchema):
 
 class UserCurrencyNetworkEventSchema(CurrencyNetworkEventSchema):
     direction = fields.Str()
+    address = Address(attribute='counter_party')
     counterParty = Address(attribute='counter_party')
     user = Address()
 
@@ -43,6 +44,7 @@ class TokenEventSchema(BlockchainEventSchema):
 
 class UserTokenEventSchema(TokenEventSchema):
     direction = fields.Str()
+    address = Address(attribute='counter_party')
     counterParty = Address(attribute='counter_party')
     user = Address()
 

--- a/relay/blockchain/events.py
+++ b/relay/blockchain/events.py
@@ -46,7 +46,7 @@ class TLNetworkEvent(BlockchainEvent):
             return 'received'
 
     @property
-    def other_party(self):
+    def counter_party(self):
         if self.user is None:
             return None
         if self.from_ == self.user:

--- a/relay/events.py
+++ b/relay/events.py
@@ -46,7 +46,7 @@ class BalanceEvent(AccountEvent):
                          timestamp)
         self.from_ = from_
         self.to = to
-        self.other_party = to
+        self.counter_party = to
 
 
 class NetworkBalanceEvent(AccountEvent):

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -73,7 +73,7 @@ def test_get_events(currency_network_with_events, accounts):
     currency_network = currency_network_with_events
     creditline_update_events = currency_network.get_network_events(CreditlineUpdateEventType, user_address=accounts[0])
     e1, e2, e3 = creditline_update_events
-    assert (e1.other_party, e2.other_party, e3.other_party) == (accounts[1], accounts[2], accounts[4])
+    assert (e1.counter_party, e2.counter_party, e3.counter_party) == (accounts[1], accounts[2], accounts[4])
 
 
 def test_get_transfer_event(currency_network_with_events, accounts):
@@ -83,7 +83,7 @@ def test_get_transfer_event(currency_network_with_events, accounts):
     assert transfer_event.to == accounts[0]
     assert transfer_event.from_ == accounts[1]
     assert transfer_event.user == accounts[0]
-    assert transfer_event.other_party == accounts[1]
+    assert transfer_event.counter_party == accounts[1]
     assert transfer_event.direction == 'received'
 
 

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -66,7 +66,7 @@ def test_trustline_update_event(web3_event_trustline_update):
     assert event.from_ == '0x123'
     assert event.to == '0x1234'
     assert event.user == '0x1234'
-    assert event.other_party == '0x123'
+    assert event.counter_party == '0x123'
     assert event.given == 50
     assert event.received == 100
     assert event.status == 'confirmed'
@@ -79,7 +79,7 @@ def test_transfer_event(web3_event_transfer):
     assert event.from_ == '0x123'
     assert event.to == '0x1234'
     assert event.user == '0x123'
-    assert event.other_party == '0x1234'
+    assert event.counter_party == '0x1234'
     assert event.value == 150
     assert event.status == 'pending'
     assert event.direction == 'sent'


### PR DESCRIPTION
Add users own address as user in returned events
Change counter partys address from address into counterParty in returned events
Downgrade gevent as the new version broke web3 v3
Closes #130