### PR TITLE
Exchange events endpoint for all exchanges

### DIFF
--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -13,7 +13,7 @@ from .resources import GraphDump, GraphImage, RequestEther, User, UserList, Netw
 from .streams.app import WebSocketRPCHandler, MessagingWebSocketRPCHandler
 
 from .exchange.resources import OrderBook, OrderSubmission, ExchangeAddresses, UnwEthAddresses, OrderDetail, \
-    Orders, UserEventsExchange, EventsExchange
+    Orders, UserEventsExchange, EventsExchange, UserEventsAllExchanges
 
 from .messaging.resources import PostMessage
 from .tokens.resources import TokenAddresses, EventsToken, TokenBalance, UserEventsToken
@@ -80,6 +80,7 @@ def ApiApp(trustlines):
     add_resource(UnwEthAddresses, '/exchange/eth')
     add_resource(OrderDetail, '/exchange/order/<string:order_hash>')
     add_resource(UserEventsExchange, '/exchange/<address:exchange_address>/users/<address:user_address>/events')
+    add_resource(UserEventsAllExchanges, '/exchange/users/<address:user_address>/events')
     add_resource(EventsExchange, '/exchange/<address:exchange_address>/events')
 
     add_resource(TokenAddresses, '/tokens')

--- a/relay/api/exchange/resources.py
+++ b/relay/api/exchange/resources.py
@@ -208,6 +208,36 @@ class UserEventsExchange(Resource):
         return UserExchangeEventSchema().dump(events, many=True).data
 
 
+class UserEventsAllExchanges(Resource):
+
+    def __init__(self, trustlines: TrustlinesRelay) -> None:
+        self.trustlines = trustlines
+
+    args = {
+        'fromBlock': webfields.Int(required=False, missing=0),
+        'type': webfields.Str(required=False,
+                              validate=validate.OneOf(ExchangeProxy.event_types),
+                              missing=None)
+    }
+
+    @use_args(args)
+    def get(self, args, user_address: str):
+        from_block = args['fromBlock']
+        type = args['type']
+        try:
+            events = self.trustlines.get_all_user_exchange_events(user_address,
+                                                                  type=type,
+                                                                  from_block=from_block)
+        except TimeoutException:
+            logger.warning(
+                "User exchange events from all exchanges: event_name=%s user_address=%s from_block=%s. could not get events in time",
+                type,
+                user_address,
+                from_block)
+            abort(504, TIMEOUT_MESSAGE)
+        return UserExchangeEventSchema().dump(events, many=True).data
+
+
 class EventsExchange(Resource):
 
     def __init__(self, trustlines: TrustlinesRelay) -> None:

--- a/relay/api/exchange/resources.py
+++ b/relay/api/exchange/resources.py
@@ -230,7 +230,8 @@ class UserEventsAllExchanges(Resource):
                                                                   from_block=from_block)
         except TimeoutException:
             logger.warning(
-                "User exchange events from all exchanges: event_name=%s user_address=%s from_block=%s. could not get events in time",
+                """User exchange events from all exchanges:
+                   event_name=%s user_address=%s from_block=%s. could not get events in time""",
                 type,
                 user_address,
                 from_block)

--- a/relay/blockchain/exchange_events.py
+++ b/relay/blockchain/exchange_events.py
@@ -10,6 +10,8 @@ class ExchangeEvent(TLNetworkEvent):
     def __init__(self, web3_event, current_blocknumber, timestamp, user=None):
         super().__init__(web3_event, current_blocknumber, timestamp, from_to_types, user)
         self.exchange_address = web3_event.get('address')
+        # NOTE: The argument orderHash can be a hex string because the indexer currently can
+        #       not save bytes in the database. See issue https://github.com/trustlines-network/py-eth-index/issues/16
         if (is_hex(web3_event.get('args').get('orderHash'))):
             self.order_hash = decode_hex(web3_event.get('args').get('orderHash'))
         else:

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -400,6 +400,16 @@ class TrustlinesRelay:
                                                    timeout=self.event_query_timeout)
         return events
 
+    def get_all_user_exchange_events(self,
+                                     user_address: str,
+                                     type: str=None,
+                                     from_block: int=0,
+                                     timeout: float=None) -> List[BlockchainEvent]:
+        assert is_checksum_address(user_address)
+        exchange_event_queries = self._get_exchange_event_queries(user_address, type, from_block)
+        results = concurrency_utils.joinall(exchange_event_queries, timeout=timeout)
+        return sorted_events(list(itertools.chain.from_iterable(results)))
+
     def _load_config(self):
         with open('config.json') as data_file:
             self.config = json.load(data_file)


### PR DESCRIPTION
- Adds endpoint `/exchange/users/<address:user_address>/events` for retrieving exchange events from all exchanges
- Also adds a comment on issue https://github.com/trustlines-network/py-eth-index/issues/16