### PR TITLE
use docker images in docker/trustlines

### DIFF
--- a/docker/trustlines/docker-compose.yml
+++ b/docker/trustlines/docker-compose.yml
@@ -32,12 +32,10 @@ services:
     restart: unless-stopped
 
   relay:
+    image: trustlines/relay
     depends_on:
       - "db"
       - "parity"
-    build:
-      #context: https://github.com/trustlines-network/relay.git#develop
-      context: ../..
     volumes:
       - ./config.json:/relay/config.json
       - ./addresses.json:/relay/addresses.json
@@ -56,11 +54,10 @@ services:
     restart: unless-stopped
 
   index:
+    image: trustlines/py-eth-index
     depends_on:
       - "db"
       - "parity"
-    build:
-      context: https://github.com/trustlines-network/py-eth-index.git#develop
     environment:
       - PGHOST
       - PGUSER


### PR DESCRIPTION
please note that we use the latest tag, just like we did previously by using the
develop branch.

see https://github.com/trustlines-network/relay/issues/166