### PR TITLE
travis: use build stages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+build
+dist
+*.egg-info
+*.egg/
+*.eggs/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.swp
+*~
+
+.tox
+.coverage
+html/*
+__pycache__
+
+# Compiled Documentation
+docs/_build
+
+.mypy_cache/
+.idea
+venv/
+local/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,62 @@
+dist: trusty
+sudo: false
 language: python
 python:
 - '3.6'
 git:
   depth: false
-install:
-- curl -L -o $HOME/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.21/solc-static-linux
-  && chmod +x $HOME/bin/solc
-- pip install -c constraints.txt populus
-- pip install codecov
-- pip install -c constraints.txt -r requirements.txt
-- pip install -c constraints.txt -e .
-script:
-- flake8
-- mypy --ignore-missing-imports relay
-- pytest --cov=relay tests
-- docker build -t relay .
-after_success:
-- codecov
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: ".travis/push-docker-image"
-  on:
-    branch: develop
 branches:
   only:
   - master
   - develop
-services:
-- docker
+  - /^[0-9]+/
+stages:
+  - name: testing
+  - name: deploying
+
 env:
   global:
-  - DOCKER_USER=trustlinesautomation
   - THREADING_BACKEND=gevent
-  - secure: TMCObpO6yl9vW0Yp2skrRa9Exph5LO8aWniePHJKbldt3wKV+x7Ab0V2hD2/dZES85Pdqs7a1nSMOGMB60EZ9CiAr07LOZfltH7NsDuK+c5jqDffi+Wa8KW+CrNT/2lQ1Hz/eyVMHLUhUJEatUB4JzmhvaeRMkqRtkP+M6NaXub3mg9AFigr+aHZ/5Zl2l2z8CekAS4sLtrdcIR2cKYmUCJySpg9CVSM8VCOGouw+I7Y6QC6vn7MABGcpeUxsgdbUQag0xe5uBlTR6pOEp4UGHWC0kpvipNIdh8HhTECe9GhN0NltqL4HqBs1hsrnntta3bOFFjph/LljuWExo5X/w++Oy3p30wOuO7VSWjSPOXOiIFaADwlHzn08WerQextZmr/Q6c7VbH/BxJk/GMpG5CCvMCRUI4lON5zXLC6Z3N26w2PgA2cHnu792znInuVfW+qrGFVAo1owD9o18BBVlBJ1u4TjMr3viTy0enKJw7ksECg9Mh6mOtTiD+jhAZQlwH/eX0O3PbK3FQuu9p9x1O6OP3IKZIzGVJm3nS7jgqMYFONeHhoFKf7x1fPLfPbCSZrgu3tJnzxBFFAfi015uzUSk0mN9DALfTO04G7W9x4xxke8czn4EZyaFzP11zvft3T8VfQeh6fTTju+FEwRBgDiGyxRwO9okz31GYyQ0o=
 notifications:
   webhooks:
     urls:
     - secure: GQq5gi4oaDgJ6QQvNb1xnGMHlTzY38g/IePsURExefZi4AXUlaCbJOmR+XVZv+Dhz4GzSZ+BQ7WoWRZTu2wvyn/b/00JSieBmyMMobGSaNE1wjSdDTVTYnZV3TQgoHvlSQWpEPiuTFPVsvvbTkJgf2n5vtv+MsvkZHTHjsjtM4GC7Xi0ykzqiREsJlBf+mwqz5gsu7kVANeTtsBPBPEDM4ELhm5exa/fvvsw5N/9nmfFWkOTtZvVx03vacTJowZB2mIczmq6amdQ76ZwPAuzXsVTAT/vivBEEFm0Enicki2k3rj7JKdG+x2uerVsRGUHF3AbvI0Jcb/KOx7YtCgxU4KUDy0b6DdRn4uN72g3lt5eMhaOF9NP9DMIp0+4PSSQQRubuKgnHR5u40hbc2cz/sVaprrq4I+mTiubwaAwjD4AXMYOAqwTJ8DYwxHE1qo94w/bJ/FvNn+L0aTR/cWb0r002RDIGT0NPGm43Q3Me1VPA4o71bO/erllorvo5wuBRsPCHQinXBe9a1FVnkSd+MSxx5DXSG3p5HJnhKJTJLrJDLtDGVVVD8YOZEZDly4pli/27yAgoD6OcIaWdk0yGcPvzLaYgu4W8fdA1E6BTKnqq04lylUEeXKpXBzogeL1nlZBTxG6sIrVVSmXTTAH1Kt5I7kAiXt07V9o8kLmZAY=
     on_success: change
     on_failure: always
+
+jobs:
+  include:
+    - stage: testing
+      install:
+      - curl -L -o $HOME/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.21/solc-static-linux
+        && chmod +x $HOME/bin/solc
+      - pip install -c constraints.txt populus
+      - pip install -c constraints.txt codecov
+      - pip install -c constraints.txt -r requirements.txt
+      - pip install -c constraints.txt -e .
+      script:
+      - flake8
+      - mypy --ignore-missing-imports relay
+      - pytest --cov=relay tests
+      after_success:
+      - codecov
+
+    - stage: deploying
+      name: docker
+      sudo: true
+      service: docker
+      env:
+        - DOCKER_USER=trustlinesautomation
+        - secure: TMCObpO6yl9vW0Yp2skrRa9Exph5LO8aWniePHJKbldt3wKV+x7Ab0V2hD2/dZES85Pdqs7a1nSMOGMB60EZ9CiAr07LOZfltH7NsDuK+c5jqDffi+Wa8KW+CrNT/2lQ1Hz/eyVMHLUhUJEatUB4JzmhvaeRMkqRtkP+M6NaXub3mg9AFigr+aHZ/5Zl2l2z8CekAS4sLtrdcIR2cKYmUCJySpg9CVSM8VCOGouw+I7Y6QC6vn7MABGcpeUxsgdbUQag0xe5uBlTR6pOEp4UGHWC0kpvipNIdh8HhTECe9GhN0NltqL4HqBs1hsrnntta3bOFFjph/LljuWExo5X/w++Oy3p30wOuO7VSWjSPOXOiIFaADwlHzn08WerQextZmr/Q6c7VbH/BxJk/GMpG5CCvMCRUI4lON5zXLC6Z3N26w2PgA2cHnu792znInuVfW+qrGFVAo1owD9o18BBVlBJ1u4TjMr3viTy0enKJw7ksECg9Mh6mOtTiD+jhAZQlwH/eX0O3PbK3FQuu9p9x1O6OP3IKZIzGVJm3nS7jgqMYFONeHhoFKf7x1fPLfPbCSZrgu3tJnzxBFFAfi015uzUSk0mN9DALfTO04G7W9x4xxke8czn4EZyaFzP11zvft3T8VfQeh6fTTju+FEwRBgDiGyxRwO9okz31GYyQ0o=
+
+      install: /bin/true
+      script:
+        - docker build -t relay .
+
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: ".travis/push-docker-image"
+        on:
+          all_branches: true
+          condition: $TRAVIS_BRANCH =~ ^(develop|[0-9]+.*)$

--- a/.travis/push-docker-image
+++ b/.travis/push-docker-image
@@ -2,17 +2,20 @@
 
 set -e
 
+DOCKER_REPO=trustlines/relay
+LOCAL_IMAGE=relay
+
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
 
-version=$(python -c 'import pkg_resources; print(pkg_resources.get_distribution("trustlines-relay").version.replace("+", "_"))')
+version=$(docker run --entrypoint '' --rm $LOCAL_IMAGE cat VERSION | tr '+' '_')
 
 echo "Tagging with $version"
 echo "=====> pushing to dockerhub"
 
 set -x
 
-docker tag relay trustlines/relay:$version
-docker push trustlines/relay:$version
+docker tag $LOCAL_IMAGE $DOCKER_REPO:$version
+docker push $DOCKER_REPO:$version
 
-docker tag relay trustlines/relay:latest
-docker push trustlines/relay:latest
+docker tag $LOCAL_IMAGE $DOCKER_REPO:latest
+docker push $DOCKER_REPO:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,35 @@
-FROM python:3.5
+FROM python:3.5 as base
 
 RUN apt-get update && \
     apt-get install -y apt-utils libssl-dev curl graphviz
 
+FROM base AS builder
 RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.21/solc-static-linux && \
     chmod +x /usr/bin/solc
+
+RUN python3 -m venv /opt/relay
+RUN /opt/relay/bin/pip install pip==18.0.0 setuptools==40.0.0
 
 COPY ./constraints.txt /relay/constraints.txt
 COPY ./requirements.txt /relay/requirements.txt
 
 WORKDIR /relay
 
-RUN pip install -c constraints.txt populus
-RUN pip install -c constraints.txt -r requirements.txt
+RUN /opt/relay/bin/pip install -c constraints.txt populus
+RUN /opt/relay/bin/pip install -c constraints.txt -r requirements.txt
 
 ENV THREADING_BACKEND gevent
 
 COPY . /relay
 
-RUN pip install -c constraints.txt .
+RUN /opt/relay/bin/pip install -c constraints.txt .
+RUN /opt/relay/bin/python -c 'import pkg_resources; print(pkg_resources.get_distribution("trustlines-relay").version)' >/opt/relay/VERSION
+
+FROM base
+RUN rm -rf /var/lib/apt/lists/*
+ENV THREADING_BACKEND gevent
+COPY --from=builder /opt/relay /opt/relay
+RUN ln -s /opt/relay/bin/tl-relay /usr/local/bin/
+WORKDIR /opt/relay
 
 ENTRYPOINT ["tl-relay"]


### PR DESCRIPTION
We use build stages, so that we have a chance to hide our DOCKER_PASSWORD.

The Dockerfile itself now also uses a staged build and copies the virtualenv to
/opt/relay. The base image itself hasn't changed, i.e. I haven't upgraded to
ubuntu 18.04.

The build is pretty much consistent now with what we're doing in the watch and
py-eth-index repositories.

This will also trigger the deploy stage for tags.