### PR TITLE
fix docker-compose based setup

### DIFF
--- a/docker/trustlines/README.md
+++ b/docker/trustlines/README.md
@@ -38,7 +38,7 @@ docker-compose up --no-start
 
 We need the compiled contracts, which are installed in the relay server image. Copy them with:
 ```
-docker run --rm -it -v $(pwd):/tmp --entrypoint /bin/bash trustlines_relay -c "cp /usr/local/trustlines-contracts/build/contracts.json /tmp"
+docker-compose run --rm --no-deps -v $(pwd):/here --entrypoint /bin/bash relay -c "cp /opt/relay/trustlines-contracts/build/contracts.json /here"
 ```
 
 We need to start the index container for initial database setup:

--- a/docker/trustlines/docker-compose.yml
+++ b/docker/trustlines/docker-compose.yml
@@ -37,8 +37,8 @@ services:
       - "db"
       - "parity"
     volumes:
-      - ./config.json:/relay/config.json
-      - ./addresses.json:/relay/addresses.json
+      - ./config.json:/opt/relay/config.json
+      - ./addresses.json:/opt/relay/addresses.json
     # make relay server listen on port 5000. In a real scenario you will want to
     # put a proxy like nginx, apache or traefik in front of the relay server
     ports:


### PR DESCRIPTION
The config files for the relay server have to live in the current directory and
we need to copy the contracts.json from a different path.