### PR TITLE
Read the feeDivisor value from contract

### DIFF
--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -10,6 +10,8 @@ import gevent
 import relay.concurrency_utils as concurrency_utils
 from .proxy import Proxy, reconnect_interval, sorted_events
 from relay.logger import get_logger
+from web3.exceptions import BadFunctionCallOutput, ValidationError
+
 
 from .events import BlockchainEvent
 from .currency_network_events import (
@@ -52,6 +54,10 @@ class CurrencyNetworkProxy(Proxy):
         self.name = self._proxy.call().name().strip('\0')  # type: str
         self.decimals = self._proxy.call().decimals()  # typ: str
         self.symbol = self._proxy.call().symbol().strip('\0')  # type: str
+        try:
+            self.capacityImbalanceFeeDivisor = self._proxy.call().capacityImbalanceFeeDivisor()
+        except (BadFunctionCallOutput, ValidationError) as e:
+            self.capacityImbalanceFeeDivisor = 100
 
     @property
     def users(self) -> List[str]:

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -169,10 +169,11 @@ class TrustlinesRelay:
         if address in self.networks:
             return
         logger.info('New network: {}'.format(address))
-        self.currency_network_graphs[address] = CurrencyNetworkGraph(100)
         self.currency_network_proxies[address] = CurrencyNetworkProxy(self._web3,
                                                                       self.contracts['CurrencyNetwork']['abi'],
                                                                       address)
+        self.currency_network_graphs[address] = CurrencyNetworkGraph(
+            self.currency_network_proxies[address].capacityImbalanceFeeDivisor)
         self._start_listen_network(address)
 
     def new_exchange(self, address: str) -> None:


### PR DESCRIPTION
Read the feeDivisor value from contract when generating network instead of using 100.
Related to https://github.com/trustlines-network/relay/issues/194