### PR TITLE
Wip/synchronized relay tx

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -27,7 +27,7 @@ from relay.concurrency_utils import TimeoutException
 from relay.logger import get_logger
 
 
-logger = get_logger('api.resources', logging.DEBUG)
+logger = get_logger('apiresources', logging.DEBUG)
 
 
 TIMEOUT_MESSAGE = 'The server could not handle the request in time'
@@ -289,6 +289,8 @@ class TransactionInfos(Resource):
 
 class Relay(Resource):
 
+    txcounter = 0
+
     def __init__(self, trustlines: TrustlinesRelay) -> None:
         self.trustlines = trustlines
 
@@ -298,11 +300,15 @@ class Relay(Resource):
 
     @use_args(args)
     def post(self, args):
+        Relay.txcounter += 1
+        txcounter = Relay.txcounter
         try:
+            logger.info("start relaying transaction #%s", txcounter)
             transaction_id = self.trustlines.node.relay_tx(args['rawTransaction'])
         except ValueError:  # should mean error in relaying the transaction
             abort(409, 'There was an error while relaying this transaction')
 
+        logger.info("relayed transaction #%s with transaction id %s", txcounter, transaction_id.hex())
         return transaction_id.hex()
 
 

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -289,8 +289,6 @@ class TransactionInfos(Resource):
 
 class Relay(Resource):
 
-    txcounter = 0
-
     def __init__(self, trustlines: TrustlinesRelay) -> None:
         self.trustlines = trustlines
 
@@ -300,15 +298,10 @@ class Relay(Resource):
 
     @use_args(args)
     def post(self, args):
-        Relay.txcounter += 1
-        txcounter = Relay.txcounter
         try:
-            logger.info("start relaying transaction #%s", txcounter)
             transaction_id = self.trustlines.node.relay_tx(args['rawTransaction'])
         except ValueError:  # should mean error in relaying the transaction
             abort(409, 'There was an error while relaying this transaction')
-
-        logger.info("relayed transaction #%s with transaction id %s", txcounter, transaction_id.hex())
         return transaction_id.hex()
 
 

--- a/relay/main.py
+++ b/relay/main.py
@@ -4,6 +4,7 @@ from gevent import monkey; monkey.patch_all(thread=False)  # noqa: E702
 import psycogreen.gevent; psycogreen.gevent.patch_psycopg()  # noqa: E702
 import logging
 
+import pkg_resources
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
 
@@ -41,8 +42,15 @@ def patch_warnings_module():
     logger.info("the warnings module has been patched. You will not see the DeprecationWarning messages from web3")
 
 
+def get_version():
+    try:
+        return pkg_resources.get_distribution("trustlines-relay").version
+    except pkg_resources.DistributionNotFound:
+        return "<UNKNOWN>"
+
+
 def main():
-    logger.info('Starting relay server')
+    logger.info('Starting relay server version %s', get_version())
     patch_warnings_module()
     trustlines = TrustlinesRelay()
     trustlines.start()


### PR DESCRIPTION
This makes it possible to run the end2end tests again. We enable a workaround via an environment variable setting (TRUSTLINES_END2END=1, see commit cbc6d6c921f7aa976c877d29270cc4fa)

Will open another PR in the clientlib that enables the workaround.