### PR TITLE
Refactor/web3update

### DIFF
--- a/docker/trustlines/docker-compose.yml
+++ b/docker/trustlines/docker-compose.yml
@@ -44,7 +44,6 @@ services:
     ports:
       - "5000:5000"
     environment:
-      - ETHINDEX=1
       - PGHOST
       - PGUSER
       - PGDATABASE

--- a/docs/RelayServer.md
+++ b/docs/RelayServer.md
@@ -217,7 +217,7 @@ The relay server reads both files from the current directory, so we need to star
 
 ```
 cd ~
-ETHINDEX=1 ~/opt/relay/bin/tl-relay
+~/opt/relay/bin/tl-relay
 ```
 
 The relay server needs access to the parity node and the PostgreSQL database.

--- a/relay/api/exchange/resources.py
+++ b/relay/api/exchange/resources.py
@@ -1,10 +1,13 @@
 import logging
+
+import hexbytes
 from flask_restful import Resource
 from webargs.flaskparser import use_args
 from webargs import fields as webfields
 from webargs.flaskparser import abort
 from eth_utils import to_checksum_address, is_hex
 from marshmallow import validate
+
 from relay.relay import TrustlinesRelay
 from relay.api import fields
 from relay.api.exchange.schemas import OrderSchema
@@ -62,7 +65,7 @@ class OrderDetail(Resource):
 
     def get(self, order_hash: str):
         abort_if_invalid_order_hash(order_hash)
-        order = self.trustlines.orderbook.get_order_by_hash(bytes.fromhex(order_hash[2:]))
+        order = self.trustlines.orderbook.get_order_by_hash(hexbytes.HexBytes(order_hash))
         if order is None:
             abort(404, message='Order does not exist')
         return OrderSchema().dump(order).data

--- a/relay/api/fields.py
+++ b/relay/api/fields.py
@@ -1,3 +1,4 @@
+import hexbytes
 from webargs import ValidationError
 from marshmallow import fields
 from eth_utils import is_address, to_checksum_address
@@ -42,8 +43,8 @@ class HexBytes(fields.String):
     def _deserialize(self, value, attr, data):
         value = super()._deserialize(value, attr, data)
         try:
-            int_value = int(value, 16).to_bytes(32, 'big')
+            hex_bytes = hexbytes.HexBytes(value)
         except ValueError:
             raise ValidationError('Could not parse Hex number')
 
-        return int_value
+        return hex_bytes

--- a/relay/api/schemas.py
+++ b/relay/api/schemas.py
@@ -16,7 +16,7 @@ class MessageEventSchema(EventSchema):
 class BlockchainEventSchema(EventSchema):
     blockNumber = fields.Integer(attribute='blocknumber')
     type = fields.Str(default='event')
-    transactionId = fields.Str(attribute='transaction_id')
+    transactionId = HexBytes(attribute='transaction_id')
     status = fields.Str()
 
 

--- a/relay/blockchain/exchange_events.py
+++ b/relay/blockchain/exchange_events.py
@@ -1,4 +1,5 @@
-from eth_utils import is_hex, decode_hex
+import hexbytes
+
 from .events import TLNetworkEvent, BlockchainEvent  # NOQA
 
 LogFillEventType = 'LogFill'
@@ -12,10 +13,11 @@ class ExchangeEvent(TLNetworkEvent):
         self.exchange_address = web3_event.get('address')
         # NOTE: The argument orderHash can be a hex string because the indexer currently can
         #       not save bytes in the database. See issue https://github.com/trustlines-network/py-eth-index/issues/16
-        if (is_hex(web3_event.get('args').get('orderHash'))):
-            self.order_hash = decode_hex(web3_event.get('args').get('orderHash'))
+        order_hash = web3_event.get('args').get('orderHash')
+        if not isinstance(order_hash, hexbytes.HexBytes):
+            self.order_hash = hexbytes.HexBytes(order_hash)
         else:
-            self.order_hash = web3_event.get('args').get('orderHash')
+            self.order_hash = order_hash
         self.maker_token = web3_event.get('args').get('makerToken')
         self.taker_token = web3_event.get('args').get('takerToken')
 

--- a/relay/blockchain/exchange_proxy.py
+++ b/relay/blockchain/exchange_proxy.py
@@ -42,21 +42,22 @@ class ExchangeProxy(Proxy):
             return True
         else:
             maker_token = self._token_contract(address=order.maker_token)
-            return (maker_token.call().balanceOf(order.maker_address) >= order.maker_token_amount and
+            return (maker_token.functions.balanceOf(order.maker_address).call() >= order.maker_token_amount and
                     (self._is_trusted_token(order.maker_token) or
-                     maker_token.call().allowance(order.maker_address, self.address) >= order.maker_token_amount))
+                     maker_token.functions.allowance(order.maker_address,
+                                                     self.address).call() >= order.maker_token_amount))
 
     def validate_filled_amount(self, order: Order) -> bool:
-        return self._proxy.call().getUnavailableTakerTokenAmount(order.hash()) < order.taker_token_amount
+        return self._proxy.functions.getUnavailableTakerTokenAmount(order.hash()).call() < order.taker_token_amount
 
     def get_filled_amount(self, order: Order) -> int:
-        return self._proxy.call().filled(order.hash())
+        return self._proxy.functions.filled(order.hash()).call()
 
     def get_cancelled_amount(self, order: Order) -> int:
-        return self._proxy.call().cancelled(order.hash())
+        return self._proxy.functions.cancelled(order.hash()).call()
 
     def get_unavailable_amount(self, order: Order) -> int:
-        return self._proxy.call().getUnavailableTakerTokenAmount(order.hash())
+        return self._proxy.functions.getUnavailableTakerTokenAmount(order.hash()).call()
 
     def start_listen_on_fill(self, f) -> None:
         def log(log_entry):

--- a/relay/blockchain/proxy.py
+++ b/relay/blockchain/proxy.py
@@ -44,7 +44,7 @@ class Proxy(object):
         self._proxy = web3.eth.contract(abi=abi, address=address)
         self.address = address
 
-    def _watch_filter(self, eventname: str, function, params=None):
+    def _watch_filter(self, eventname: str, function: Callable, params: Dict = None):
         while True:
             try:
                 filter = getattr(self._proxy.events, eventname).createFilter(**params)
@@ -61,7 +61,7 @@ class Proxy(object):
                 logger.warning('ValueError in filter creation, try to reconnect:' + str(err))
                 gevent.sleep(reconnect_interval)
 
-    def start_listen_on(self, eventname: str, function, params=None) -> None:
+    def start_listen_on(self, eventname: str, function: Callable, params: Dict = None) -> None:
         def on_exception(filter):
             logger.warning('Filter {} disconnected, trying to reconnect'.format(filter))
             gevent.sleep(reconnect_interval)
@@ -83,7 +83,7 @@ class Proxy(object):
 
         logfilter = getattr(self._proxy.events, event_name).createFilter(
             fromBlock=from_block,
-            toBlock="latest",
+            toBlock=queryBlock,
             argument_filters=filter_)
 
         queries = [logfilter.get_all_entries]

--- a/relay/blockchain/token_proxy.py
+++ b/relay/blockchain/token_proxy.py
@@ -29,7 +29,7 @@ class TokenProxy(Proxy):
         super().__init__(web3, token_abi, address)
 
     def balance_of(self, user_address: str):
-        return self._proxy.call().balanceOf(user_address)
+        return self._proxy.functions.balanceOf(user_address).call()
 
     def get_token_events(self,
                          event_name: str,

--- a/relay/exchange/order.py
+++ b/relay/exchange/order.py
@@ -139,8 +139,8 @@ class SignableOrder(Order):
                          expiration_timestamp_in_sec,
                          salt,
                          v=0,
-                         r=hexbytes.HexBytes('0x00'),
-                         s=hexbytes.HexBytes('0x00'))
+                         r=hexbytes.HexBytes(b''),
+                         s=hexbytes.HexBytes(b''))
 
     def sign(self, key) -> None:
         v, r, s = eth_sign(self.hash(), key)

--- a/relay/exchange/order.py
+++ b/relay/exchange/order.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+import hexbytes
 from eth_utils import is_checksum_address
 
 from relay.signing import keccak256, eth_sign, eth_validate
@@ -25,8 +26,8 @@ class Order(object):
         expiration_timestamp_in_sec: int,
         salt: int,
         v: int,
-        r: bytes,
-        s: bytes,
+        r: hexbytes.HexBytes,
+        s: hexbytes.HexBytes,
         filled_maker_token_amount: int = 0,
         filled_taker_token_amount: int = 0,
         cancelled_maker_token_amount: int = 0,
@@ -86,8 +87,8 @@ class Order(object):
     def is_filled(self) -> bool:
         return self.available_maker_token_amount <= 0 or self.available_taker_token_amount <= 0
 
-    def hash(self) -> bytes:
-        return keccak256(
+    def hash(self) -> hexbytes.HexBytes:
+        return hexbytes.HexBytes(keccak256(
             self.exchange_address,
             self.maker_address,
             self.taker_address,
@@ -100,7 +101,7 @@ class Order(object):
             self.taker_fee,
             self.expiration_timestamp_in_sec,
             self.salt
-        )
+        ))
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Order):
@@ -138,11 +139,11 @@ class SignableOrder(Order):
                          expiration_timestamp_in_sec,
                          salt,
                          v=0,
-                         r=b'',
-                         s=b'')
+                         r=hexbytes.HexBytes('0x00'),
+                         s=hexbytes.HexBytes('0x00'))
 
     def sign(self, key) -> None:
         v, r, s = eth_sign(self.hash(), key)
         self.v = v
-        self.r = r
-        self.s = s
+        self.r = hexbytes.HexBytes(r)
+        self.s = hexbytes.HexBytes(s)

--- a/relay/exchange/orderbook.py
+++ b/relay/exchange/orderbook.py
@@ -2,6 +2,7 @@ import time
 from typing import Tuple, Sequence, Iterable
 
 import gevent
+import hexbytes
 
 from relay.blockchain.exchange_proxy import ExchangeProxy
 from relay.constants import NULL_ADDRESS
@@ -61,7 +62,7 @@ class OrderBook(object):
     def delete_order(self, order: Order) -> None:
         self.delete_order_by_hash(order.hash())
 
-    def delete_order_by_hash(self, order_hash: bytes) -> None:
+    def delete_order_by_hash(self, order_hash: hexbytes.HexBytes) -> None:
         if self._db is not None:
             self._db.delete_order_by_hash(order_hash)
 
@@ -107,13 +108,13 @@ class OrderBook(object):
         return []
 
     def order_cancelled(self,
-                        orderhash: bytes,
+                        orderhash: hexbytes.HexBytes,
                         cancelled_maker_amount: int,
                         cancelled_taker_amount: int) -> None:
         if self._db is not None:
             return self._db.order_cancelled(orderhash, cancelled_maker_amount, cancelled_taker_amount)
 
-    def get_order_by_hash(self, order_hash: bytes):
+    def get_order_by_hash(self, order_hash: hexbytes.HexBytes):
         if self._db is not None:
             return self._db.get_order_by_hash(order_hash)
 

--- a/relay/main.py
+++ b/relay/main.py
@@ -51,7 +51,6 @@ def get_version():
 
 def main():
     logger.info('Starting relay server version %s', get_version())
-    patch_warnings_module()
     trustlines = TrustlinesRelay()
     trustlines.start()
     ipport = ('', 5000)

--- a/relay/signing.py
+++ b/relay/signing.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from eth_keys import keys
 from eth_keys.exceptions import BadSignature
 from eth_utils import (
@@ -50,7 +52,7 @@ def keccak256(*args) -> bytes:
     return keccak(pack(*args))
 
 
-def eth_sign(hash, key):
+def eth_sign(hash: bytes, key: bytes) -> Tuple[int, bytes, bytes]:
     v, r, s = keys.PrivateKey(key).sign_msg_hash(keccak256(b'\x19Ethereum Signed Message:\n32', hash)).vrs
     if v < 27:
         v += 27

--- a/tests/chain_integration/conftest.py
+++ b/tests/chain_integration/conftest.py
@@ -16,11 +16,10 @@ NETWORKS = [('Fugger', 'FUG', 2), ('Hours', 'HOU', 2), ('Testcoin', 'T', 6)]
 
 
 @pytest.fixture(scope="session")
-def ethereum_tester_session():
+def ethereum_tester_session(test_account):
     """Returns an instance of an Ethereum tester"""
     tester = eth_tester.EthereumTester(eth_tester.PyEVMBackend())
-    k0 = b'\x04HR\xb2\xa6p\xad\xe5@~x\xfb(c\xc5\x1d\xe9\xfc\xb9eB\xa0q\x86\xfe:\xed\xa6\xbb\x8a\x11m'
-    a0 = tester.add_account(encode_hex(k0))
+    a0 = tester.add_account(encode_hex(test_account.private_key))
     faucet = tester.get_accounts()[0]
     tester.send_transaction(
         {"from": faucet,
@@ -55,9 +54,9 @@ def accounts(web3):
 
 
 @pytest.fixture
-def maker(tester):
+def maker(test_account):
     """checksum maker address"""
-    return to_checksum_address(tester.a0)
+    return test_account.address
 
 
 @pytest.fixture
@@ -174,43 +173,29 @@ def network_addresses_with_exchange(testnetworks):
 
 @pytest.fixture()
 def currency_network(web3, currency_network_abi, testnetwork1_address):
-    """this currency network is not reset for speed reasons,
-       only use it for constant tests"""
     currency_network = CurrencyNetworkProxy(web3, currency_network_abi, testnetwork1_address)
     return currency_network
 
 
 @pytest.fixture()
 def currency_network_with_trustlines(web3, currency_network_abi, testnetwork2_address, trustlines):
-    """this currency network is not reset for speed reasons,
-        only use it for constant tests"""
     currency_network = CurrencyNetworkProxy(web3, currency_network_abi, testnetwork2_address)
-
     currency_network.setup_trustlines(trustlines)
 
     return currency_network
 
 
 @pytest.fixture()
-def fresh_currency_network(web3, currency_network_abi, testnetwork3_address, trustlines):
-    """this currency network is reset on every use which is very slow,
-            only use it if you need it"""
-    currency_network = CurrencyNetworkProxy(web3, currency_network_abi, testnetwork3_address)
+def currency_network_with_events(currency_network, accounts):
+    currency_network.update_creditline(accounts[0], accounts[1], 25)
+    currency_network.accept_creditline(accounts[1], accounts[0], 25)
+    currency_network.transfer(accounts[1], accounts[0], 10, 10, [accounts[0]])
+    currency_network.update_creditline(accounts[0], accounts[2], 25)
+    currency_network.accept_creditline(accounts[2], accounts[0], 25)
+    currency_network.update_creditline(accounts[0], accounts[4], 25)
+    currency_network.accept_creditline(accounts[4], accounts[0], 25)
 
     return currency_network
-
-
-@pytest.fixture()
-def currency_network_with_events(fresh_currency_network, accounts):
-    fresh_currency_network.update_creditline(accounts[0], accounts[1], 25)
-    fresh_currency_network.accept_creditline(accounts[1], accounts[0], 25)
-    fresh_currency_network.transfer(accounts[1], accounts[0], 10, 10, [accounts[0]])
-    fresh_currency_network.update_creditline(accounts[0], accounts[2], 25)
-    fresh_currency_network.accept_creditline(accounts[2], accounts[0], 25)
-    fresh_currency_network.update_creditline(accounts[0], accounts[4], 25)
-    fresh_currency_network.accept_creditline(accounts[4], accounts[0], 25)
-
-    return fresh_currency_network
 
 
 @pytest.fixture()

--- a/tests/chain_integration/conftest.py
+++ b/tests/chain_integration/conftest.py
@@ -69,23 +69,24 @@ class CurrencyNetworkProxy(CurrencyNetworkProxy):
 
     def setup_trustlines(self, trustlines):
         for (A, B, clAB, clBA) in trustlines:
-            txid = self._proxy.transact().setAccount(A, B, clAB, clBA, 0, 0, 0, 0, 0, 0)
+            txid = self._proxy.functions.setAccount(A, B, clAB, clBA, 0, 0, 0, 0, 0, 0).transact()
             self._web3.eth.waitForTransactionReceipt(txid)
 
     def update_creditline(self, from_, to, value):
-        txid = self._proxy.transact({"from": from_}).updateCreditline(to, value)
+        txid = self._proxy.functions.updateCreditline(to, value).transact({"from": from_})
         self._web3.eth.waitForTransactionReceipt(txid)
 
     def accept_creditline(self, from_, to, value):
-        txid = self._proxy.transact({"from": from_}).acceptCreditline(to, value)
+        txid = self._proxy.functions.acceptCreditline(to, value).transact({"from": from_})
         self._web3.eth.waitForTransactionReceipt(txid)
 
     def update_trustline(self, from_, to, creditline_given, creditline_received):
-        txid = self._proxy.transact({"from": from_}).updateTrustline(to, creditline_given, creditline_received)
+        txid = self._proxy.functions.updateTrustline(to, creditline_given, creditline_received).transact(
+            {"from": from_})
         self._web3.eth.waitForTransactionReceipt(txid)
 
     def transfer(self, from_, to, value, max_fee, path):
-        txid = self._proxy.transact({"from": from_}).transfer(to, value, max_fee, path)
+        txid = self._proxy.functions.transfer(to, value, max_fee, path).transact({"from": from_})
         self._web3.eth.waitForTransactionReceipt(txid)
 
 
@@ -147,11 +148,11 @@ def testnetwork3_address(web3):
 def testnetworks(web3, maker, taker):
     currency_network_contracts, exchange_contract, unw_eth_contract = deploy_test_networks(web3)
 
-    unw_eth_contract.transact({'from': taker, 'value': 200}).deposit()
+    unw_eth_contract.functions.deposit().transact({'from': taker, 'value': 200})
 
     currency_network = currency_network_contracts[0]
-    currency_network.transact({'from': taker}).updateCreditline(maker, 300)
-    currency_network.transact({'from': maker}).acceptCreditline(taker, 300)
+    currency_network.functions.updateCreditline(maker, 300).transact({'from': taker})
+    currency_network.functions.acceptCreditline(taker, 300).transact({'from': maker})
 
     return currency_network_contracts, exchange_contract, unw_eth_contract
 

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -92,8 +92,7 @@ def test_number_of_get_all_events(currency_network_with_events, accounts):
     assert len(currency_network.get_all_network_events(user_address=accounts[0])) == 7
 
 
-def test_listen_on_creditline_update(fresh_currency_network, accounts):
-    currency_network = fresh_currency_network
+def test_listen_on_creditline_update(currency_network, accounts):
     events = []
 
     def f(event):
@@ -111,8 +110,7 @@ def test_listen_on_creditline_update(fresh_currency_network, accounts):
     assert events[0].value == 25
 
 
-def test_listen_on_balance_update(fresh_currency_network, accounts):
-    currency_network = fresh_currency_network
+def test_listen_on_balance_update(currency_network, accounts):
     events = []
 
     def f(event):
@@ -131,8 +129,7 @@ def test_listen_on_balance_update(fresh_currency_network, accounts):
     assert (-12 < events[0].value < 12)  # because there might be fees
 
 
-def test_listen_on_transfer(fresh_currency_network, accounts):
-    currency_network = fresh_currency_network
+def test_listen_on_transfer(currency_network, accounts):
     events = []
 
     def f(event):
@@ -151,8 +148,7 @@ def test_listen_on_transfer(fresh_currency_network, accounts):
     assert events[0].value == 10
 
 
-def test_listen_on_trustline_update(fresh_currency_network, accounts):
-    currency_network = fresh_currency_network
+def test_listen_on_trustline_update(currency_network, accounts):
     events = []
 
     def f(event):

--- a/tests/chain_integration/test_exchange_proxy.py
+++ b/tests/chain_integration/test_exchange_proxy.py
@@ -7,10 +7,10 @@ from relay.exchange.order import SignableOrder
 
 
 @pytest.fixture()
-def order_token(exchange_address, network_addresses_with_exchange, unw_eth_address, tester, maker):
+def order_token(exchange_address, network_addresses_with_exchange, unw_eth_address, test_account):
     order = SignableOrder(
         exchange_address=exchange_address,
-        maker_address=maker,
+        maker_address=test_account.address,
         taker_address=NULL_ADDRESS,
         maker_token=unw_eth_address,
         taker_token=network_addresses_with_exchange[0],
@@ -22,15 +22,15 @@ def order_token(exchange_address, network_addresses_with_exchange, unw_eth_addre
         expiration_timestamp_in_sec=1230000000000,
         salt=123
         )
-    order.sign(tester.k0)
+    order.sign(test_account.private_key)
     return order
 
 
 @pytest.fixture()
-def order_trustlines(exchange_address, network_addresses_with_exchange, unw_eth_address, tester, maker):
+def order_trustlines(exchange_address, network_addresses_with_exchange, unw_eth_address, test_account):
     order = SignableOrder(
         exchange_address=exchange_address,
-        maker_address=maker,
+        maker_address=test_account.address,
         taker_address=NULL_ADDRESS,
         maker_token=network_addresses_with_exchange[0],
         taker_token=unw_eth_address,
@@ -42,7 +42,7 @@ def order_trustlines(exchange_address, network_addresses_with_exchange, unw_eth_
         expiration_timestamp_in_sec=1230000000000,
         salt=123
         )
-    order.sign(tester.k0)
+    order.sign(test_account.private_key)
     return order
 
 

--- a/tests/chain_integration/test_exchange_proxy.py
+++ b/tests/chain_integration/test_exchange_proxy.py
@@ -67,7 +67,7 @@ def test_not_enough_funds(order_token, exchange_proxy):
 
 def test_enough_funds(order_token, exchange_proxy, testnetworks):
     unw_eth_contract = testnetworks[2]
-    unw_eth_contract.transact({'from': order_token.maker_address, 'value': 100}).deposit()
+    unw_eth_contract.functions.deposit().transact({'from': order_token.maker_address, 'value': 100})
 
     assert exchange_proxy.validate_funds(order_token)
     assert exchange_proxy.validate(order_token)
@@ -81,7 +81,7 @@ def test_filled_amount(order_trustlines, exchange_proxy, testnetworks, maker, ta
     order = order_trustlines
 
     exchange_contract = testnetworks[1]
-    exchange_contract.transact({'from': taker}).fillOrderTrustlines(
+    exchange_contract.functions.fillOrderTrustlines(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
@@ -90,12 +90,12 @@ def test_filled_amount(order_trustlines, exchange_proxy, testnetworks, maker, ta
         [maker],
         order.v,
         order.r,
-        order.s)
+        order.s).transact({'from': taker})
 
     assert exchange_proxy.get_filled_amount(order) == 100
     assert exchange_proxy.validate_filled_amount(order)
 
-    exchange_contract.transact({'from': taker}).fillOrderTrustlines(
+    exchange_contract.functions.fillOrderTrustlines(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
@@ -104,7 +104,7 @@ def test_filled_amount(order_trustlines, exchange_proxy, testnetworks, maker, ta
         [maker],
         order.v,
         order.r,
-        order.s)
+        order.s).transact({'from': taker})
 
     assert exchange_proxy.get_filled_amount(order) == 200
     assert not exchange_proxy.validate_filled_amount(order)
@@ -114,11 +114,11 @@ def test_cancelled_amount(order_trustlines, exchange_proxy, testnetworks, maker,
     order = order_trustlines
 
     exchange_contract = testnetworks[1]
-    exchange_contract.transact({'from': maker}).cancelOrder(
+    exchange_contract.functions.cancelOrder(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
-        100)
+        100).transact({'from': maker})
 
     assert exchange_proxy.get_cancelled_amount(order) == 100
 
@@ -128,7 +128,7 @@ def test_unavailable_amount(order_trustlines, exchange_proxy, testnetworks, make
 
     exchange_contract = testnetworks[1]
 
-    exchange_contract.transact({'from': taker}).fillOrderTrustlines(
+    exchange_contract.functions.fillOrderTrustlines(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
@@ -137,13 +137,13 @@ def test_unavailable_amount(order_trustlines, exchange_proxy, testnetworks, make
         [maker],
         order.v,
         order.r,
-        order.s)
+        order.s).transact({'from': taker})
 
-    exchange_contract.transact({'from': maker}).cancelOrder(
+    exchange_contract.functions.cancelOrder(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
-        10)
+        10).transact({'from': maker})
 
     assert exchange_proxy.get_unavailable_amount(order) == 20
 
@@ -160,7 +160,7 @@ def test_listen_on_fill(order_trustlines, exchange_proxy, testnetworks, maker, t
     gevent.sleep(0.001)
 
     exchange_contract = testnetworks[1]
-    exchange_contract.transact({'from': taker}).fillOrderTrustlines(
+    exchange_contract.functions.fillOrderTrustlines(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
@@ -169,7 +169,7 @@ def test_listen_on_fill(order_trustlines, exchange_proxy, testnetworks, maker, t
         [],
         order.v,
         order.r,
-        order.s)
+        order.s).transact({'from': taker})
 
     gevent.sleep(1)
 
@@ -191,11 +191,11 @@ def test_listen_on_cancel(order_token, exchange_proxy, testnetworks, maker, take
     gevent.sleep(0.001)
 
     exchange_contract = testnetworks[1]
-    exchange_contract.transact({'from': maker}).cancelOrder(
+    exchange_contract.functions.cancelOrder(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
-        100)
+        100).transact({'from': maker})
 
     gevent.sleep(1)
 

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -49,9 +49,9 @@ def community_with_trustlines(currency_network_with_trustlines):
 
 
 @pytest.fixture()
-def fresh_community(fresh_currency_network):
+def fresh_community(currency_network):
     community = CurrencyNetworkGraph(100)
-    link_graph(fresh_currency_network, community)
+    link_graph(currency_network, community)
     gevent.sleep(0.0001)
     return community
 
@@ -78,11 +78,11 @@ def test_no_capacity(community_with_trustlines, accounts):
     assert path == []
 
 
-def test_creditline_update(fresh_community, fresh_currency_network, accounts):
+def test_creditline_update(fresh_community, currency_network, accounts):
     A, B, *rest = accounts
 
-    fresh_currency_network.update_creditline(A, B, 50)
-    fresh_currency_network.accept_creditline(B, A, 50)
+    currency_network.update_creditline(A, B, 50)
+    currency_network.accept_creditline(B, A, 50)
 
     gevent.sleep(1)
 
@@ -90,11 +90,11 @@ def test_creditline_update(fresh_community, fresh_currency_network, accounts):
     assert fresh_community.get_account_sum(A, B).creditline_received == 0
 
 
-def test_trustline_update(fresh_community, fresh_currency_network, accounts):
+def test_trustline_update(fresh_community, currency_network, accounts):
     A, B, *rest = accounts
 
-    fresh_currency_network.update_trustline(A, B, 50, 100)
-    fresh_currency_network.update_trustline(B, A, 100, 50)
+    currency_network.update_trustline(A, B, 50, 100)
+    currency_network.update_trustline(B, A, 100, 50)
 
     gevent.sleep(1)
 
@@ -102,12 +102,12 @@ def test_trustline_update(fresh_community, fresh_currency_network, accounts):
     assert fresh_community.get_account_sum(A, B).creditline_received == 100
 
 
-def test_transfer_update(fresh_community, fresh_currency_network, accounts):
+def test_transfer_update(fresh_community, currency_network, accounts):
     A, B, *rest = accounts
 
-    fresh_currency_network.update_trustline(A, B, 50, 100)
-    fresh_currency_network.update_trustline(B, A, 100, 50)
-    fresh_currency_network.transfer(B, A, 20, 1, [A])
+    currency_network.update_trustline(A, B, 50, 100)
+    currency_network.update_trustline(B, A, 100, 50)
+    currency_network.transfer(B, A, 20, 1, [A])
 
     gevent.sleep(1)
 

--- a/tests/chain_integration/tlcontracts_deploy.py
+++ b/tests/chain_integration/tlcontracts_deploy.py
@@ -54,7 +54,7 @@ def get_contract_factory(web3, contract_name):
 
 def deploy(contract_name, web3, *args):
     contract = get_contract_factory(web3, contract_name)
-    txhash = contract.deploy(args=args)
+    txhash = contract.constructor(*args).transact()
     receipt = check_successful_tx(web3, txhash)
     id_address = receipt["contractAddress"]
     return contract(id_address)
@@ -73,8 +73,8 @@ def deploy_unw_eth(web3, exchange_address=None):
     unw_eth = deploy("UnwEth", web3)
     if exchange_address is not None:
         if exchange_address is not None:
-            txid = unw_eth.transact(
-                {"from": web3.eth.accounts[0]}).addAuthorizedAddress(exchange_address)
+            txid = unw_eth.functions.addAuthorizedAddress(exchange_address).transact(
+                {"from": web3.eth.accounts[0]})
             check_successful_tx(web3, txid)
     return unw_eth
 
@@ -82,12 +82,12 @@ def deploy_unw_eth(web3, exchange_address=None):
 def deploy_network(web3, name, symbol, decimals, fee_divisor=100, exchange_address=None):
     currency_network = deploy("CurrencyNetwork", web3)
 
-    txid = currency_network.transact(
-        {"from": web3.eth.accounts[0]}).init(name, symbol, decimals, fee_divisor)
+    txid = currency_network.functions.init(name, symbol, decimals, fee_divisor).transact(
+        {"from": web3.eth.accounts[0]})
     check_successful_tx(web3, txid)
     if exchange_address is not None:
-        txid = currency_network.transact(
-            {"from": web3.eth.accounts[0]}).addAuthorizedAddress(exchange_address)
+        txid = currency_network.functions.addAuthorizedAddress(exchange_address).transact(
+            {"from": web3.eth.accounts[0]})
         check_successful_tx(web3, txid)
 
     return currency_network
@@ -101,29 +101,29 @@ def deploy_proxied_network(web3, name, symbol, decimals, fee_divisor=100, exchan
     proxy = deploy("EtherRouter", web3, resolver.address)
     print(proxy.address)
     proxied_trustlines = get_contract_factory(web3, "CurrencyNetwork")(proxy.address)
-    txid = proxied_trustlines.transact().init(name, symbol, decimals, fee_divisor)
+    txid = proxied_trustlines.functions.init(name, symbol, decimals, fee_divisor).transact()
     check_successful_tx(web3, txid)
     if exchange_address is not None:
-        txid = proxied_trustlines.transact().addAuthorizedAddress(exchange_address)
+        txid = proxied_trustlines.functions.addAuthorizedAddress(exchange_address).transact()
         check_successful_tx(web3, txid)
 
-    txid = resolver.transact().registerLengthFunction("getUsers()",
-                                                      "getUsersReturnSize()",
-                                                      currency_network_address)
+    txid = resolver.functions.registerLengthFunction("getUsers()",
+                                                     "getUsersReturnSize()",
+                                                     currency_network_address).transact()
     check_successful_tx(web3, txid)
-    txid = resolver.transact().registerLengthFunction("getFriends(address)",
-                                                      "getFriendsReturnSize(address)",
-                                                      currency_network_address)
+    txid = resolver.functions.registerLengthFunction("getFriends(address)",
+                                                     "getFriendsReturnSize(address)",
+                                                     currency_network_address).transact()
     check_successful_tx(web3, txid)
-    txid = resolver.transact().registerLengthFunction("getAccount(address,address)",
-                                                      "getAccountLen()",
-                                                      currency_network_address)
+    txid = resolver.functions.registerLengthFunction("getAccount(address,address)",
+                                                     "getAccountLen()",
+                                                     currency_network_address).transact()
     check_successful_tx(web3, txid)
-    txid = resolver.transact().registerLengthFunction("name()", "nameLen()",
-                                                      currency_network_address)
+    txid = resolver.functions.registerLengthFunction("name()", "nameLen()",
+                                                     currency_network_address).transact()
     check_successful_tx(web3, txid)
-    txid = resolver.transact().registerLengthFunction("symbol()", "symbolLen()",
-                                                      currency_network_address)
+    txid = resolver.functions.registerLengthFunction("symbol()", "symbolLen()",
+                                                     currency_network_address).transact()
     check_successful_tx(web3, txid)
     return proxied_trustlines
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,12 +12,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 Account = namedtuple('Account', 'address private_key')
 
 
-@pytest.fixture(scope="session", autouse=True)
-def silence_deprecation_warnings():
-    from relay.main import patch_warnings_module
-    patch_warnings_module()
-
-
 @pytest.fixture(scope="session")
 def addresses() -> Sequence[str]:
     return [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
 import os
 import sys
 from typing import Sequence
+from collections import namedtuple
 
 import pytest
 
 # import the relay module so no pip install is necessary
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+Account = namedtuple('Account', 'address private_key')
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -14,7 +18,7 @@ def silence_deprecation_warnings():
     patch_warnings_module()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def addresses() -> Sequence[str]:
     return [
         '0x379162D7682cb8Bb6435c47E0B8B562eAFE66971',
@@ -24,14 +28,8 @@ def addresses() -> Sequence[str]:
     ]
 
 
-@pytest.fixture()
-def tester():
-    """ethereum.tools.tester compatible class"""
-
-    class tester:
-        pass
-
-    t = tester()
-    t.k0 = b'\x04HR\xb2\xa6p\xad\xe5@~x\xfb(c\xc5\x1d\xe9\xfc\xb9eB\xa0q\x86\xfe:\xed\xa6\xbb\x8a\x11m'
-    t.a0 = b'\x82\xa9x\xb3\xf5\x96*[\tW\xd9\xee\x9e\xefG.\xe5[B\xf1'
-    return t
+@pytest.fixture(scope="session")
+def test_account():
+    return Account(
+        private_key=b'\x04HR\xb2\xa6p\xad\xe5@~x\xfb(c\xc5\x1d\xe9\xfc\xb9eB\xa0q\x86\xfe:\xed\xa6\xbb\x8a\x11m',
+        address='0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1')

--- a/tests/integration/exchange/conftest.py
+++ b/tests/integration/exchange/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 from sqlalchemy import create_engine
-from eth_utils import to_checksum_address
 
 from relay.exchange.order import SignableOrder
 from relay.constants import NULL_ADDRESS
@@ -12,9 +11,9 @@ def engine():
 
 
 @pytest.fixture()
-def orders(addresses, tester):
+def orders(addresses, test_account):
     A, B, C, D = addresses
-    maker = to_checksum_address(tester.a0)
+    maker = test_account.address
     orders = [
         SignableOrder(
             exchange_address=A,
@@ -83,7 +82,7 @@ def orders(addresses, tester):
             salt=123
         )]
     for order in orders:
-        order.sign(tester.k0)
+        order.sign(test_account.private_key)
     return orders
 
 

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,23 +1,22 @@
-from eth_utils import to_checksum_address
 from relay.signing import eth_validate, eth_sign
 
 
-def test_eth_validate(tester):
+def test_eth_validate(test_account):
     msg_hash = bytes(32)
-    vrs = eth_sign(msg_hash, tester.k0)
-    assert eth_validate(msg_hash, vrs, to_checksum_address(tester.a0))
+    vrs = eth_sign(msg_hash, test_account.private_key)
+    assert eth_validate(msg_hash, vrs, test_account.address)
 
 
-def test_eth_validate_fail(tester):
+def test_eth_validate_fail(test_account):
     msg_hash1 = bytes(32)
     msg_hash2 = (123).to_bytes(32, byteorder='big')
-    vrs = eth_sign(msg_hash1, tester.k0)
-    assert not eth_validate(msg_hash2, vrs, to_checksum_address(tester.a0))
+    vrs = eth_sign(msg_hash1, test_account.private_key)
+    assert not eth_validate(msg_hash2, vrs, test_account.address)
 
 
-def test_eth_validate_fail2(tester):
+def test_eth_validate_fail2(test_account):
     msg_hash = bytes(32)
     v = 27
     r = 18
     s = 2748
-    assert not eth_validate(msg_hash, (v, r, s), to_checksum_address(tester.a0))
+    assert not eth_validate(msg_hash, (v, r, s), test_account.address)

--- a/tests/unit/exchange/conftest.py
+++ b/tests/unit/exchange/conftest.py
@@ -27,9 +27,9 @@ def invalid_signature_order(addresses):
 
 
 @pytest.fixture()
-def invalid_exchange_order(addresses, tester):
+def invalid_exchange_order(addresses, test_account):
     A, B, C, D = addresses
-    maker = tester.a0
+    maker = test_account.address
     order = SignableOrder(
         exchange_address='0x379162d7682cb8bb6435c47E0b8b562eafe66971',
         maker_address=to_checksum_address(maker),
@@ -43,14 +43,14 @@ def invalid_exchange_order(addresses, tester):
         taker_fee=0,
         expiration_timestamp_in_sec=123,
         salt=123)
-    order.sign(tester.k0)
+    order.sign(test_account.private_key)
     return order
 
 
 @pytest.fixture()
-def invalid_taker_order(addresses, tester):
+def invalid_taker_order(addresses, test_account):
     A, B, C, D = addresses
-    maker = tester.a0
+    maker = test_account.address
     order = SignableOrder(
         exchange_address=A,
         maker_address=to_checksum_address(maker),
@@ -64,14 +64,14 @@ def invalid_taker_order(addresses, tester):
         taker_fee=0,
         expiration_timestamp_in_sec=123,
         salt=123)
-    order.sign(tester.k0)
+    order.sign(test_account.private_key)
     return order
 
 
 @pytest.fixture()
-def expired_order(addresses, tester):
+def expired_order(addresses, test_account):
     A, B, C, D = addresses
-    maker = tester.a0
+    maker = test_account.address
     order = SignableOrder(
         exchange_address=A,
         maker_address=to_checksum_address(maker),
@@ -85,14 +85,14 @@ def expired_order(addresses, tester):
         taker_fee=0,
         expiration_timestamp_in_sec=123,
         salt=123)
-    order.sign(tester.k0)
+    order.sign(test_account.private_key)
     return order
 
 
 @pytest.fixture()
-def valid_order(addresses, tester):
+def valid_order(addresses, test_account):
     A, B, C, D = addresses
-    maker = tester.a0
+    maker = test_account.address
     order = SignableOrder(
         exchange_address=A,
         maker_address=to_checksum_address(maker),
@@ -106,6 +106,6 @@ def valid_order(addresses, tester):
         taker_fee=0,
         expiration_timestamp_in_sec=1517161470000,
         salt=123)
-    order.sign(tester.k0)
+    order.sign(test_account.private_key)
 
     return order


### PR DESCRIPTION
Remove the ETHINDEX flag as it is now the default
Use hexbytes datatype internally instead of removing it
Remove tester mock class and instead use a testaccount
Refactored call() and transact to new web3 v4 pattern