### PR TITLE
Fix/path finding

### DIFF
--- a/relay/network_graph/alg.py
+++ b/relay/network_graph/alg.py
@@ -1,0 +1,146 @@
+"""graph algorithms"""
+
+import heapq
+from typing import List, Set, Dict, Callable, Iterable
+import networkx as nx
+import abc
+
+
+class CostAccumulator(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def zero(self):
+        """return 'zero cost' element, which is the initial cost for a one-node path
+
+        This must be less than or equal to any value
+        total_cost_from_start_to_dst returns.
+        """
+        pass
+
+    @abc.abstractmethod
+    def total_cost_from_start_to_dst(
+        self, cost_from_start_to_node, node, dst, edge_data
+    ):
+        """
+        compute the total cost from one of the starting nodes to dst via node
+        given that the cost from one of the starting nodes to node is the given parameter
+        cost_from_start_to_node.
+
+        In other words this adds the cost for the hop from node to dst to
+        cost_from_start_to_node.
+
+        edge_data is the data that's stored inside the graph for the edge from
+        node to dst.
+
+        This function must return a value greater or equal to the given
+        cost_from_start_to_node parameter when used with the least_cost_path
+        function below, since that implement dijkstra's graph finding
+        algorithm, where negative weights are not allowed.
+
+        It may also return None, which means that this path - from one of the
+        starting nodes, to node, to dst - is forbidden.
+        """
+        pass
+
+    def compute_cost_for_path(self, graph: nx.graph.Graph, path: List):
+        cost = self.zero()
+        for source, dst in zip(path, path[1:]):
+            cost = self.total_cost_from_start_to_dst(
+                cost, source, dst, graph.get_edge_data(source, dst)
+            )
+        return cost
+
+
+def _build_path_from_backlinks(dst: List, backlinks: Dict):
+    path = [dst]
+    while True:
+        dst = backlinks[dst]
+        if dst is None:
+            path.reverse()
+            return path
+        path.append(dst)
+
+
+def _least_cost_path_helper(
+    graph: nx.graph.Graph,
+    target_nodes: Set,
+    queue: List,
+    least_costs: Dict,
+    backlinks: Dict,
+    cost_fn: Callable,
+    max_cost=None
+    #    node_filter,
+    #    edge_filter,
+):
+    graph_adj = graph.adj
+
+    while queue:
+        cost_from_start_to_node, node = heapq.heappop(queue)
+        if node in target_nodes:
+            return cost_from_start_to_node, _build_path_from_backlinks(node, backlinks)
+
+        if cost_from_start_to_node > least_costs[node]:
+            continue  # we already found a cheaper path to node
+
+        for dst, edge_data in graph_adj[node].items():
+            cost_from_start_to_dst = cost_fn(
+                cost_from_start_to_node, node, dst, edge_data
+            )
+            if cost_from_start_to_dst is None:  # cost_fn decided this path is forbidden
+                continue
+
+            if max_cost is not None and max_cost < cost_from_start_to_dst:
+                continue
+
+            assert cost_from_start_to_dst >= cost_from_start_to_node
+
+            least_cost_found_so_far_from_start_to_dst = least_costs.get(dst)
+            if (
+                least_cost_found_so_far_from_start_to_dst is None
+                or cost_from_start_to_dst < least_cost_found_so_far_from_start_to_dst
+            ):
+                heapq.heappush(queue, (cost_from_start_to_dst, dst))
+                least_costs[dst] = cost_from_start_to_dst
+                backlinks[dst] = node
+
+    raise nx.NetworkXNoPath("no path found")
+
+
+def least_cost_path(
+    *,
+    graph: nx.graph.Graph,
+    starting_nodes: Iterable,
+    target_nodes: Set,
+    cost_accumulator: CostAccumulator,
+    max_cost=None,
+):
+    """find the path through the given graph with least cost from one of the
+    starting_nodes to one of the target_nodes
+
+    cost_accumulator is used to compute the cost
+
+    When max_cost is given, only return a path, whose cost is smaller than
+    max_cost.
+
+    This is an implementation of dijkstra's multi-source multi-target path
+    finding algorithm. As a result the given cost_accumulator's
+    total_cost_from_start_to_dst function must return a value that's equal or
+    greater than it's given cost_from_start_to_node parameter, i.e. it must not
+    use 'negative costs'.
+    """
+    zero_cost = cost_accumulator.zero()
+    cost_fn = cost_accumulator.total_cost_from_start_to_dst
+    assert max_cost is None or zero_cost <= max_cost
+
+    least_costs: Dict = {}
+    backlinks: Dict = {}
+    queue: List = []
+    for node in starting_nodes:
+        if not graph.has_node(node):
+            continue
+        least_costs[node] = zero_cost
+        backlinks[node] = None
+        heapq.heappush(queue, (zero_cost, node))
+
+    return _least_cost_path_helper(
+        graph, target_nodes, queue, least_costs, backlinks, cost_fn, max_cost=max_cost
+    )

--- a/relay/network_graph/dijkstra_weighted.py
+++ b/relay/network_graph/dijkstra_weighted.py
@@ -5,56 +5,53 @@ import math
 
 import networkx as nx
 import attr
+from . import alg
+
+
+class FeesFirstSenderPaysCostAccumulator(alg.CostAccumulator):
+    def __init__(self, value, get_fee, max_hops=None, max_fees=None, ignore=None):
+        if max_hops is None:
+            max_hops = math.inf
+        if max_fees is None:
+            max_fees = math.inf
+
+        self.value = value
+        self.get_fee = get_fee
+        self.max_hops = max_hops
+        self.max_fees = max_fees
+        self.ignore = ignore
+
+    def zero(self):
+        return (0, 0)
+
+    def total_cost_from_start_to_dst(
+        self, cost_from_start_to_node, node, dst, graph_data
+    ):
+        if dst == self.ignore or node == self.ignore:
+            return None
+
+        sum_fees, num_hops = cost_from_start_to_node
+
+        if num_hops + 1 > self.max_hops:
+            return None
+
+        fee = self.get_fee(graph_data, dst, node, self.value + sum_fees)
+
+        if fee is None or sum_fees + fee > self.max_fees:
+            return None
+
+        return (sum_fees + fee, num_hops + 1)
 
 
 def find_path(G, source, target, get_fee, value, max_hops=None, max_fees=None, ignore=None):
-    G_adj = G.adj
-
-    paths = {source: [source]}  # dictionary of paths
-
-    push = heappush
-    pop = heappop
-    dist = {}  # dictionary of final distances
-    dist_hop = {}  # dictionary of final distances in terms of hops
-    seen = {source: value}
-    c = count()
-    fringe = []  # use heapq with (distance,label) tuples
-    push(fringe, (0, value, next(c), source))
-    while fringe:
-        (n, d, _, v) = pop(fringe)
-        if v in dist:
-            continue  # already searched this node.
-        if v == ignore:
-            continue
-        dist[v] = d
-        dist_hop[v] = n
-        if v == target:
-            break
-
-        for u, e in G_adj[v].items():
-            cost = get_fee(e, u, v, d)  # fee of transferring from u to v
-            if cost is None:
-                continue
-            vu_dist = d + cost
-            if max_fees is not None:
-                if vu_dist - value > max_fees:
-                    continue
-            if max_hops is not None:
-                if n + 1 > max_hops:
-                    continue
-            if u in dist:
-                if (n+1, vu_dist) < (dist_hop[u], dist[u]):
-                    raise ValueError('Contradictory paths found:',
-                                     'negative weights?')
-            elif u not in seen or vu_dist < seen[u]:
-                seen[u] = vu_dist
-                push(fringe, (n+1, vu_dist, next(c), u))
-                paths[u] = paths[v] + [u]
-    try:
-        return (dist[target]-value, paths[target])  # cost is the total fee, not the actual amount to be transfered
-    except KeyError:
-        raise nx.NetworkXNoPath(
-            "node %s not reachable from %s" % (source, target))
+    cost_accumulator = FeesFirstSenderPaysCostAccumulator(
+        value, get_fee, max_hops=max_hops, max_fees=max_fees, ignore=ignore)
+    cost, path = alg.least_cost_path(
+        graph=G,
+        starting_nodes={source},
+        target_nodes={target},
+        cost_accumulator=cost_accumulator)
+    return cost[0], path
 
 
 def find_maximum_capacity_path(G, source, target, get_capacity, max_hops=None):

--- a/tests/unit/network_graph/test_find_path.py
+++ b/tests/unit/network_graph/test_find_path.py
@@ -1,0 +1,40 @@
+import pytest
+
+import networkx as nx
+from relay.network_graph.dijkstra_weighted import find_path
+
+
+@pytest.fixture()
+def graph():
+    g = nx.Graph()
+
+    # 1 -> 2 -> 3
+    # 1 -> 3
+
+    g.add_edge(1, 2, fee=1)
+    g.add_edge(2, 3, fee=1)
+    g.add_edge(1, 3, fee=100)
+    return g
+
+
+def sanity_check_fees(graph, cost_path):
+    print(f"Checking {cost_path}")
+    cost, path = cost_path
+
+    sum_fees = 0
+    for source, target in zip(path, path[1:]):
+        fee = graph[source][target]["fee"]
+        sum_fees += fee
+        print(f"{source} -> {target}  fee={fee} sum_fees={sum_fees}")
+    assert sum_fees == cost, f"cost for this path is wrong {cost_path}"
+
+
+def test_find_path_cost_wrong_bug_issue_219(graph):
+    """our old implementation of find_path failed to compute the correct cost
+    for some paths
+
+    This is a test for https://github.com/trustlines-network/relay/issues/219"""
+    cost_path = find_path(
+        graph, source=1, target=3, get_fee=lambda e, u, v, d: e["fee"], value=0
+    )
+    sanity_check_fees(graph, cost_path)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, format
+envlist = format, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
This adds a new, clean implementatio of the path finding algorithm, where the cost function can be parametrized.
The old find_path is implemented in terms of the new function.

fixes #219 

We should be able to use this function for closing trustlines later, since it allows multi-source/multi-target path finding.

