### PR TITLE
Fix exchange tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -107,7 +107,8 @@ toolz==0.9.0
 tox==3.3.0
 traitlets==4.3.2
 trie==1.3.8
-trustlines-contracts-bin==0.3.1
+trustlines-contracts-bin==0.3.3
+trustlines-contracts-deploy==0.3.3
 typed-ast==1.1.0
 typing==3.6.6
 urllib3==1.23

--- a/tests/chain_integration/test_exchange_proxy.py
+++ b/tests/chain_integration/test_exchange_proxy.py
@@ -80,14 +80,15 @@ def test_no_filled_amount(order_token, exchange_proxy):
 def test_filled_amount(order_trustlines, exchange_proxy, testnetworks, maker, taker):
     order = order_trustlines
 
+    assert maker == order.maker_address
     exchange_contract = testnetworks[1]
     exchange_contract.functions.fillOrderTrustlines(
         [order.maker_address, order.taker_address, order.maker_token, order.taker_token, order.fee_recipient],
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
         100,
+        [taker],
         [],
-        [maker],
         order.v,
         order.r,
         order.s).transact({'from': taker})
@@ -100,8 +101,8 @@ def test_filled_amount(order_trustlines, exchange_proxy, testnetworks, maker, ta
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
         100,
+        [taker],
         [],
-        [maker],
         order.v,
         order.r,
         order.s).transact({'from': taker})
@@ -133,8 +134,8 @@ def test_unavailable_amount(order_trustlines, exchange_proxy, testnetworks, make
         [order.maker_token_amount, order.taker_token_amount, order.maker_fee,
          order.taker_fee, order.expiration_timestamp_in_sec, order.salt],
         10,
+        [taker],
         [],
-        [maker],
         order.v,
         order.r,
         order.s).transact({'from': taker})


### PR DESCRIPTION
When upgrading from solc version 4.21 to 4.25 in the
trustlines-contracts-bin package the exchange tests stopped working.
This is no wonder, because the tests were just wrong. The question
remains, why they were running before even though they were wrong.