### PR TITLE
fix duplicate log output bug

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -28,7 +28,7 @@ from relay.logger import get_logger
 
 from relay.network_graph.dijkstra_weighted import PaymentPath
 
-logger = get_logger('apiresources', logging.DEBUG)
+logger = get_logger('api.resources', logging.DEBUG)
 
 
 TIMEOUT_MESSAGE = 'The server could not handle the request in time'

--- a/relay/logger.py
+++ b/relay/logger.py
@@ -2,11 +2,9 @@ import logging
 
 
 def get_logger(name, level=logging.INFO):
+    # calling basicConfig multiple times does not have any effect, only the
+    # first call initializes the logging system
+    logging.basicConfig(format='%(asctime)s[%(levelname)s] %(name)s: %(message)s')
     logger = logging.getLogger(name)
     logger.setLevel(level)
-    ch = logging.StreamHandler()
-    ch.setLevel(level)
-    formatter = logging.Formatter('%(asctime)s[%(levelname)s] %(name)s: %(message)s')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
     return logger


### PR DESCRIPTION
Use logging.basicConfig in order to initialize the logging system.

This prevents duplicate log output.

see https://github.com/trustlines-network/relay/issues/203

Also changes back the loggers name in api.resources, that was changed in commit
2fc3928894e831ffe229cf22fa.