### PR TITLE
reduce number of requests in watch_filter

### DIFF
--- a/relay/blockchain/proxy.py
+++ b/relay/blockchain/proxy.py
@@ -32,7 +32,7 @@ def get_new_entries(filter, callback):
 def watch_filter(filter, callback):
     while 1:
         get_new_entries(filter, callback)
-        gevent.sleep(0.1)
+        gevent.sleep(1.0)
 
 
 class Proxy(object):


### PR DESCRIPTION
CPU usage of the tl-relay server process was too high. The waiting time between
two consecutive requests had been changed from 1.0s to 0.1s in commit
f5001d2416cde863.

We increase the wait time to 1.0s again. This makes CPU usage drop to below 10%.

see https://github.com/trustlines-network/relay/issues/256