### PR TITLE
Add basic verification for meta-transaction

### DIFF
--- a/docs/RelayServer.md
+++ b/docs/RelayServer.md
@@ -157,7 +157,7 @@ Installation on Ubuntu
 #### Installation of the relay server
 
 Clone the git repository, create a virtualenv and install into
-that. 
+that.
 ```
 cd ~
 git clone https://github.com/trustlines-network/relay

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -13,6 +13,7 @@ from tldeploy import identity
 from relay.utils import sha3
 from relay.blockchain.currency_network_proxy import CurrencyNetworkProxy
 from relay.blockchain.unw_eth_proxy import UnwEthProxy
+from relay.blockchain.delegate import InvalidMetaTransactionException
 from relay.api import fields as custom_fields
 from .schemas import (CurrencyNetworkEventSchema,
                       UserCurrencyNetworkEventSchema,
@@ -322,6 +323,8 @@ class RelayMetaTransaction(Resource):
         meta_transaction: identity.MetaTransaction = args["metaTransaction"]
         try:
             return self.trustlines.delegate_metatransaction(meta_transaction).hex()
+        except InvalidMetaTransactionException:
+            abort(400, 'The meta-transaction is invalid')
         except ValueError:
             abort(409, 'There was an error while relaying this meta-transaction')
 

--- a/relay/blockchain/delegate.py
+++ b/relay/blockchain/delegate.py
@@ -13,7 +13,14 @@ class Delegate:
         )
 
     def send_signed_meta_transaction(self, signed_meta_transaction: MetaTransaction,):
-        return self.delegator.send_signed_meta_transaction(signed_meta_transaction)
+        if (self.delegator.validate_meta_transaction(signed_meta_transaction)):
+            return self.delegator.send_signed_meta_transaction(signed_meta_transaction)
+        else:
+            raise InvalidMetaTransactionException
 
     def deploy_identity(self, web3, owner_address):
         return deploy_identity(web3, owner_address)
+
+
+class InvalidMetaTransactionException(Exception):
+    pass


### PR DESCRIPTION
There is no longer a way for someone to use the relay server as a delegate for a different identity contract not implementing the same nonce/signature and validation mechanism.
We might want to open an issue for creating a parallel API that send meta-transaction with no verifications.

closes https://github.com/trustlines-network/relay/issues/262