### PR TITLE
Remove time.time() from graph

### DIFF
--- a/relay/api/messaging/resources.py
+++ b/relay/api/messaging/resources.py
@@ -1,3 +1,5 @@
+import time
+
 from flask_restful import Resource
 from webargs import fields
 from webargs.flaskparser import use_args
@@ -20,6 +22,7 @@ class PostMessage(Resource):
     def post(self, args, user_address: str):
         self.trustlines.messaging[user_address].publish(MessageEvent(
             args['message'],
-            type=args['type']
+            type=args['type'],
+            timestamp=int(time.time()),
         ))
         return 'Ok'

--- a/relay/events.py
+++ b/relay/events.py
@@ -1,5 +1,3 @@
-import time
-
 from relay.network_graph.graph import AccountSummary
 
 
@@ -13,13 +11,13 @@ class Event(object):
 
 class AccountEvent(Event):
 
-    def __init__(self,
-                 network_address: str,
-                 user: str,
-                 account_summary: AccountSummary,
-                 timestamp: int = None) -> None:
-        if timestamp is None:
-            timestamp = int(time.time())
+    def __init__(
+            self,
+            network_address: str,
+            user: str,
+            account_summary: AccountSummary,
+            timestamp: int,
+    ) -> None:
         super().__init__(timestamp)
         self.user = user
         self.balance = account_summary.balance
@@ -34,12 +32,14 @@ class BalanceEvent(AccountEvent):
 
     type = 'BalanceUpdate'
 
-    def __init__(self,
-                 network_address: str,
-                 from_: str,
-                 to: str,
-                 account_summary: AccountSummary,
-                 timestamp: int = None) -> None:
+    def __init__(
+            self,
+            network_address: str,
+            from_: str,
+            to: str,
+            account_summary: AccountSummary,
+            timestamp: int,
+    ) -> None:
         super().__init__(network_address,
                          from_,
                          account_summary,
@@ -58,12 +58,13 @@ class MessageEvent(Event):
 
     type = 'Message'
 
-    def __init__(self,
-                 message: str,
-                 type: str = None,
-                 timestamp: int = None) -> None:
-        if timestamp is None:
-            timestamp = int(time.time())
+    def __init__(
+            self,
+            message: str,
+            *,
+            timestamp: int,
+            type: str = None,
+    ) -> None:
         super().__init__(timestamp)
         if type is not None:
             self.type = type

--- a/relay/network_graph/graph.py
+++ b/relay/network_graph/graph.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import time
 import math
 from typing import Iterable, Any, NamedTuple
 
@@ -498,9 +497,7 @@ class CurrencyNetworkGraph(object):
         elif self.has_interests:
             raise RuntimeError('No timestamp was given. When using interests a timestamp is mandatory')
 
-    def get_account_sum(self, user, counter_party=None, timestamp=None):
-        if timestamp is None:
-            timestamp = int(time.time())
+    def get_account_sum(self, user: str, counter_party: str = None, *, timestamp: int = 0):
 
         if counter_party is None:
             account_summary = AccountSummary()
@@ -548,7 +545,7 @@ class CurrencyNetworkGraph(object):
                              'Creditline BA': account.reverse_creditline})
         return output.getvalue()
 
-    def find_path(self, source, target, value=None, max_hops=None, max_fees=None, timestamp=None):
+    def find_path(self, source, target, value=None, max_hops=None, max_fees=None, timestamp=0):
         """
         find path between source and target
         the shortest path is found based on
@@ -557,8 +554,6 @@ class CurrencyNetworkGraph(object):
         """
         if value is None:
             value = 1
-        if timestamp is None:
-            timestamp = int(time.time())
 
         cost_accumulator = SenderPaysCostAccumulatorSnapshot(
             timestamp=timestamp,
@@ -633,7 +628,7 @@ class CurrencyNetworkGraph(object):
 
         return PaymentPath(fee=cost[0], path=path, value=value)
 
-    def find_maximum_capacity_path(self, source, target, max_hops=None, timestamp=None):
+    def find_maximum_capacity_path(self, source, target, max_hops=None, timestamp=0):
         """
         find a path probably with the maximum capacity to transfer from source to target
         The "imbalance_fee" function not being bijective, only an estimate of the fees can be found from "value + fee"
@@ -646,8 +641,6 @@ class CurrencyNetworkGraph(object):
         Returns:
             returns the value that can be send in the max capacity path and the path,
         """
-        if timestamp is None:
-            timestamp = int(time.time())
         capacity_accumulator = SenderPaysCapacityAccumulator(
             timestamp=timestamp,
             capacity_imbalance_fee_divisor=self.capacity_imbalance_fee_divisor,
@@ -685,10 +678,10 @@ class CurrencyNetworkGraphForTesting(CurrencyNetworkGraph):
             custom_interests=custom_interests,
             prevent_mediator_interests=prevent_mediator_interests)
 
-    def transfer_path(self, path, value, expected_fees):
+    def transfer_path(self, path, value, expected_fees, timestamp=0):
         assert value > 0
         cost_accumulator = SenderPaysCostAccumulatorSnapshot(
-            timestamp=int(time.time()),
+            timestamp=timestamp,
             value=value,
             capacity_imbalance_fee_divisor=self.capacity_imbalance_fee_divisor)
         cost = cost_accumulator.zero()
@@ -707,9 +700,9 @@ class CurrencyNetworkGraphForTesting(CurrencyNetworkGraph):
         assert expected_fees == cost[0]
         return cost[0]
 
-    def mediated_transfer(self, source, target, value):
+    def mediated_transfer(self, source, target, value, timestamp=0):
         """simulate mediated transfer off chain"""
-        cost, path = self.find_path(source, target, value)
+        cost, path = self.find_path(source, target, value, timestamp=timestamp)
         assert path[0] == source
         assert path[-1] == target
-        return self.transfer_path(path, value, cost)
+        return self.transfer_path(path, value, cost, timestamp=timestamp)

--- a/relay/network_graph/interests.py
+++ b/relay/network_graph/interests.py
@@ -6,6 +6,7 @@ def calculate_interests(balance: int,
                         internal_interest_rate: int,
                         delta_time_in_seconds: int,
                         highest_order: int = 15) -> int:
+    assert delta_time_in_seconds >= 0
     intermediate_order = balance
     interests = 0
     # Calculate compound interests using taylor approximation
@@ -24,6 +25,7 @@ def balance_with_interests(balance: int,
                            internal_interest_rate_positive_balance: int,
                            internal_interest_rate_negative_balance: int,
                            delta_time_in_seconds: int) -> int:
+    assert delta_time_in_seconds >= 0
     if balance > 0:
         interest = calculate_interests(balance, internal_interest_rate_positive_balance, delta_time_in_seconds)
     else:

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import gevent
 
@@ -84,10 +86,11 @@ def test_trustline_update(fresh_community, currency_network, accounts):
 
     gevent.sleep(1)
 
-    assert fresh_community.get_account_sum(A, B).creditline_given == 50
-    assert fresh_community.get_account_sum(A, B).creditline_received == 100
-    assert fresh_community.get_account_sum(A, B).interest_rate_given == 2
-    assert fresh_community.get_account_sum(A, B).interest_rate_received == 3
+    account_sum = fresh_community.get_account_sum(A, B, timestamp=int(time.time()))
+    assert account_sum.creditline_given == 50
+    assert account_sum.creditline_received == 100
+    assert account_sum.interest_rate_given == 2
+    assert account_sum.interest_rate_received == 3
 
 
 def test_transfer_update(fresh_community, currency_network, accounts):
@@ -99,8 +102,9 @@ def test_transfer_update(fresh_community, currency_network, accounts):
 
     gevent.sleep(1)
 
-    assert fresh_community.get_account_sum(A, B).creditline_given == 50
-    assert fresh_community.get_account_sum(A, B).creditline_received == 100
-    assert fresh_community.get_account_sum(A, B).balance == 20
-    assert fresh_community.get_account_sum(A, B).creditline_left_given == 30
-    assert fresh_community.get_account_sum(A, B).creditline_left_received == 120
+    account_sum = fresh_community.get_account_sum(A, B, timestamp=int(time.time()))
+    assert account_sum.creditline_given == 50
+    assert account_sum.creditline_received == 100
+    assert account_sum.balance == 20
+    assert account_sum.creditline_left_given == 30
+    assert account_sum.creditline_left_received == 120

--- a/tests/unit/network_graph/test_interests.py
+++ b/tests/unit/network_graph/test_interests.py
@@ -113,103 +113,103 @@ def test_interests_calculation_delta_time(basic_account):
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=100, m_time=1505260800, interest_rate_given=100
+                                 A, B, 200, 200, balance=100, m_time=0, interest_rate_given=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_A_balance_positive_relevant_interests(configurable_community):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=-100, m_time=1505260800, interest_rate_received=100
+                                 A, B, 200, 200, balance=-100, m_time=0, interest_rate_received=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_A_balance_negative_relevant_interests(configurable_community):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=100, m_time=1505260800, interest_rate_received=100
+                                 A, B, 200, 200, balance=100, m_time=0, interest_rate_received=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_A_balance_positive_irrelevant_interests(configurable_community):
     # B owes to A
     # 1% interest given by B to A
 
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=-100, m_time=1505260800, interest_rate_given=100
+                                 A, B, 200, 200, balance=-100, m_time=0, interest_rate_given=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_A_balance_negative_irrelevant_interests(configurable_community):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=100, m_time=1505260800, interest_rate_given=100
+                                 A, B, 200, 200, balance=100, m_time=0, interest_rate_given=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_B_balance_positive_relevant_interests(configurable_community):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=-100, m_time=1505260800, interest_rate_received=100
+                                 A, B, 200, 200, balance=-100, m_time=0, interest_rate_received=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_B_balance_negative_relevant_interests(configurable_community):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=100, m_time=1505260800, interest_rate_received=100
+                                 A, B, 200, 200, balance=100, m_time=0, interest_rate_received=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_B_balance_positive_irrelevant_interests(configurable_community):
     # B owes to A
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
 @pytest.mark.parametrize('configurable_community',
                          [NetworkGraphConfig(
                              trustlines=[Trustline(
-                                 A, B, 200, 200, balance=-100, m_time=1505260800, interest_rate_given=100
+                                 A, B, 200, 200, balance=-100, m_time=0, interest_rate_given=100
                              )])],
                          indirect=['configurable_community'])
 def test_interests_path_from_B_balance_negative_irrelevant_interests(configurable_community):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]

--- a/tests/unit/test_streams.py
+++ b/tests/unit/test_streams.py
@@ -56,7 +56,7 @@ def client():
 
 def test_subscription(subject, client):
     subscription = subject.subscribe(client)
-    subject.publish(event=MessageEvent('test'))
+    subject.publish(event=MessageEvent('test', timestamp=0))
     id = subscription.id
     item = client.events[0]
     assert item.id == id
@@ -68,7 +68,7 @@ def test_subscription(subject, client):
 def test_cancel_subscription(subject, client):
     subscription = subject.subscribe(client)
     subscription.unsubscribe()
-    subject.publish(event=MessageEvent('test'))
+    subject.publish(event=MessageEvent('test', timestamp=0))
     assert client.events == []
     assert subscription.closed
     assert len(subject.subscriptions) == 0
@@ -76,8 +76,8 @@ def test_cancel_subscription(subject, client):
 
 def test_auto_unsubscribe(subject, client):
     subscription = subject.subscribe(client)
-    subject.publish(event=MessageEvent('disconnect'))  # throws disconnected error, should unsubscribe
-    subject.publish(event=MessageEvent('test'))
+    subject.publish(event=MessageEvent('disconnect', timestamp=0))  # throws disconnected error, should unsubscribe
+    subject.publish(event=MessageEvent('test', timestamp=0))
     assert client.events == []
     assert subscription.closed
     assert len(subject.subscriptions) == 0
@@ -89,12 +89,12 @@ def test_auto_unsubscribe_dont_skip(subject):
     clients = [LogClient(), SafeLogClient()]
     for c in clients:
         subject.subscribe(c)
-    subject.publish(event=MessageEvent('disconnect'))  # the first one throws and get's auto-unsubscribed
+    subject.publish(event=MessageEvent('disconnect', timestamp=0))  # the first one throws and get's auto-unsubscribed
     assert clients[1].events, "second client not notified"
 
 
 def test_subscription_after_puplish(messaging_subject, client):
-    assert not messaging_subject.publish(event=MessageEvent('test'))
+    assert not messaging_subject.publish(event=MessageEvent('test', timestamp=0))
     subscription = messaging_subject.subscribe(client)
     missed_messages = messaging_subject.get_missed_messages()
     assert len(missed_messages) == 1
@@ -103,7 +103,7 @@ def test_subscription_after_puplish(messaging_subject, client):
 
 
 def test_subscription_after_resubscribe(messaging_subject, client):
-    messaging_subject.publish(event=MessageEvent('test'))
+    messaging_subject.publish(event=MessageEvent('test', timestamp=0))
     subscription = messaging_subject.subscribe(client)
     messaging_subject.get_missed_messages()
     subscription.unsubscribe()
@@ -114,9 +114,9 @@ def test_subscription_after_resubscribe(messaging_subject, client):
 
 
 def test_subscription_both(messaging_subject, client):
-    assert not messaging_subject.publish(event=MessageEvent('test1'))
+    assert not messaging_subject.publish(event=MessageEvent('test1', timestamp=0))
     subscription = messaging_subject.subscribe(client)
-    assert messaging_subject.publish(event=MessageEvent('test2'))
+    assert messaging_subject.publish(event=MessageEvent('test2', timestamp=0))
     id = subscription.id
     missed_messages = messaging_subject.get_missed_messages()
     assert len(missed_messages) == 1
@@ -133,7 +133,8 @@ def test_unsubscription_race_condition(subject):
     subject.subscribe(client1)
     # publish will unsubscribe because client is disconnected. Because it is delayed it will try to unsubscribe twice
     gevent.joinall(
-        (gevent.spawn(subject.publish, MessageEvent('test1')), gevent.spawn(subject.publish, MessageEvent('test2'))),
+        (gevent.spawn(subject.publish, MessageEvent('test1', timestamp=0)),
+         gevent.spawn(subject.publish, MessageEvent('test2', timestamp=0))),
         raise_error=True)
     assert subject.subscriptions == []
 


### PR DESCRIPTION
I think we forgot to merge this one, so I'm opening a PR for it. 

AFAICT this is the last step necessary to  completely fix https://github.com/trustlines-network/relay/issues/222

@berndbohmeier  Any other reason why we didn't merge this?

--- 
Remove the usage of time.time() completly from graph to make it not
depending in the time. Also remove time.time() from event creation, the
timestamp has now to be provided.
Changed the default parameter of timestamp from None to 0, so that you
can still not provide it if the timestamp is not relevant. To protect
from accidentially not providing the timestamp when it is relevant, I
added a assertion in the relevant calc interest calculation.