### PR TITLE
Remove time.time() from graph

### DIFF
--- a/relay/api/messaging/resources.py
+++ b/relay/api/messaging/resources.py
@@ -1,3 +1,5 @@
+import time
+
 from flask_restful import Resource
 from webargs import fields
 from webargs.flaskparser import use_args
@@ -18,6 +20,6 @@ class PostMessage(Resource):
     @use_args(args)
     def post(self, args, user_address: str):
         self.trustlines.messaging[user_address].publish(
-            MessageEvent(args["message"], type=args["type"])
+            MessageEvent(args["message"], type=args["type"], timestamp=int(time.time()))
         )
         return "Ok"

--- a/relay/events.py
+++ b/relay/events.py
@@ -1,5 +1,3 @@
-import time
-
 from relay.network_graph.graph import AccountSummary
 
 
@@ -17,10 +15,8 @@ class AccountEvent(Event):
         network_address: str,
         user: str,
         account_summary: AccountSummary,
-        timestamp: int = None,
+        timestamp: int,
     ) -> None:
-        if timestamp is None:
-            timestamp = int(time.time())
         super().__init__(timestamp)
         self.user = user
         self.balance = account_summary.balance
@@ -41,7 +37,7 @@ class BalanceEvent(AccountEvent):
         from_: str,
         to: str,
         account_summary: AccountSummary,
-        timestamp: int = None,
+        timestamp: int,
     ) -> None:
         super().__init__(network_address, from_, account_summary, timestamp)
         self.from_ = from_
@@ -58,9 +54,7 @@ class MessageEvent(Event):
 
     type = "Message"
 
-    def __init__(self, message: str, type: str = None, timestamp: int = None) -> None:
-        if timestamp is None:
-            timestamp = int(time.time())
+    def __init__(self, message: str, *, timestamp: int, type: str = None) -> None:
         super().__init__(timestamp)
         if type is not None:
             self.type = type

--- a/relay/network_graph/interests.py
+++ b/relay/network_graph/interests.py
@@ -8,6 +8,7 @@ def calculate_interests(
     delta_time_in_seconds: int,
     highest_order: int = 15,
 ) -> int:
+    assert delta_time_in_seconds >= 0
     intermediate_order = balance
     interests = 0
     # Calculate compound interests using taylor approximation
@@ -32,6 +33,7 @@ def balance_with_interests(
     internal_interest_rate_negative_balance: int,
     delta_time_in_seconds: int,
 ) -> int:
+    assert delta_time_in_seconds >= 0
     if balance > 0:
         interest = calculate_interests(
             balance, internal_interest_rate_positive_balance, delta_time_in_seconds

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import gevent
 
@@ -86,10 +88,11 @@ def test_trustline_update(fresh_community, currency_network, accounts):
 
     gevent.sleep(1)
 
-    assert fresh_community.get_account_sum(A, B).creditline_given == 50
-    assert fresh_community.get_account_sum(A, B).creditline_received == 100
-    assert fresh_community.get_account_sum(A, B).interest_rate_given == 2
-    assert fresh_community.get_account_sum(A, B).interest_rate_received == 3
+    account_sum = fresh_community.get_account_sum(A, B, timestamp=int(time.time()))
+    assert account_sum.creditline_given == 50
+    assert account_sum.creditline_received == 100
+    assert account_sum.interest_rate_given == 2
+    assert account_sum.interest_rate_received == 3
 
 
 def test_transfer_update(fresh_community, currency_network, accounts):
@@ -101,8 +104,9 @@ def test_transfer_update(fresh_community, currency_network, accounts):
 
     gevent.sleep(1)
 
-    assert fresh_community.get_account_sum(A, B).creditline_given == 50
-    assert fresh_community.get_account_sum(A, B).creditline_received == 100
-    assert fresh_community.get_account_sum(A, B).balance == 20
-    assert fresh_community.get_account_sum(A, B).creditline_left_given == 30
-    assert fresh_community.get_account_sum(A, B).creditline_left_received == 120
+    account_sum = fresh_community.get_account_sum(A, B, timestamp=int(time.time()))
+    assert account_sum.creditline_given == 50
+    assert account_sum.creditline_received == 100
+    assert account_sum.balance == 20
+    assert account_sum.creditline_left_given == 30
+    assert account_sum.creditline_left_received == 120

--- a/tests/unit/network_graph/test_interests.py
+++ b/tests/unit/network_graph/test_interests.py
@@ -160,13 +160,7 @@ def test_interests_calculation_delta_time(basic_account):
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=100,
-                    m_time=1505260800,
-                    interest_rate_given=100,
+                    A, B, 200, 200, balance=100, m_time=0, interest_rate_given=100
                 )
             ]
         )
@@ -178,7 +172,7 @@ def test_interests_path_from_A_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -188,13 +182,7 @@ def test_interests_path_from_A_balance_positive_relevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=-100,
-                    m_time=1505260800,
-                    interest_rate_received=100,
+                    A, B, 200, 200, balance=-100, m_time=0, interest_rate_received=100
                 )
             ]
         )
@@ -206,7 +194,7 @@ def test_interests_path_from_A_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
@@ -216,13 +204,7 @@ def test_interests_path_from_A_balance_negative_relevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=100,
-                    m_time=1505260800,
-                    interest_rate_received=100,
+                    A, B, 200, 200, balance=100, m_time=0, interest_rate_received=100
                 )
             ]
         )
@@ -235,7 +217,7 @@ def test_interests_path_from_A_balance_positive_irrelevant_interests(
     # B owes to A
     # 1% interest given by B to A
 
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -245,13 +227,7 @@ def test_interests_path_from_A_balance_positive_irrelevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=-100,
-                    m_time=1505260800,
-                    interest_rate_given=100,
+                    A, B, 200, 200, balance=-100, m_time=0, interest_rate_given=100
                 )
             ]
         )
@@ -263,7 +239,7 @@ def test_interests_path_from_A_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(A, B, 100)
+    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -273,13 +249,7 @@ def test_interests_path_from_A_balance_negative_irrelevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=100,
-                    m_time=1505260800,
-                    interest_rate_given=100,
+                    A, B, 200, 200, balance=100, m_time=0, interest_rate_given=100
                 )
             ]
         )
@@ -291,7 +261,7 @@ def test_interests_path_from_B_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
@@ -301,13 +271,7 @@ def test_interests_path_from_B_balance_positive_relevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=-100,
-                    m_time=1505260800,
-                    interest_rate_received=100,
+                    A, B, 200, 200, balance=-100, m_time=0, interest_rate_received=100
                 )
             ]
         )
@@ -319,7 +283,7 @@ def test_interests_path_from_B_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
@@ -329,13 +293,7 @@ def test_interests_path_from_B_balance_negative_relevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=100,
-                    m_time=1505260800,
-                    interest_rate_received=100,
+                    A, B, 200, 200, balance=100, m_time=0, interest_rate_received=100
                 )
             ]
         )
@@ -347,7 +305,7 @@ def test_interests_path_from_B_balance_positive_irrelevant_interests(
 ):
     # B owes to A
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
@@ -357,13 +315,7 @@ def test_interests_path_from_B_balance_positive_irrelevant_interests(
         NetworkGraphConfig(
             trustlines=[
                 Trustline(
-                    A,
-                    B,
-                    200,
-                    200,
-                    balance=-100,
-                    m_time=1505260800,
-                    interest_rate_given=100,
+                    A, B, 200, 200, balance=-100, m_time=0, interest_rate_given=100
                 )
             ]
         )
@@ -375,5 +327,5 @@ def test_interests_path_from_B_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(B, A, 100)
+    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]


### PR DESCRIPTION
replaces PR #276 

Remove the usage of time.time() completly from graph to make it not
depending in the time. Also remove time.time() from event creation, the
timestamp has now to be provided.
Changed the default parameter of timestamp from None to 0, so that you
can still not provide it if the timestamp is not relevant. To protect
from accidentially not providing the timestamp when it is relevant, I
added a assertion in the relevant calc interest calculation.