### PR TITLE
Feature/find path receiver pays api

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -33,7 +33,7 @@ https://relay0.testnet.trustlines.network/api/v1
 - [Transfer path in currency network](#transfer-path-in-currency-network)
 - [Closing trustline path in currency network](#closing-trustline-path-in-currency-network)
 - [All events in currency network](#all-events-in-currency-network)
-- [Events of user in currency network](#events-of-user-in-currency-network)
+- [Events of a user in currency network](#events-of-a-user-in-currency-network)
 ### User context
 - [Events of user in all currency networks](#events-of-user-in-all-currency-networks)
 - [Transaction infos for user](#transaction-infos-for-user)
@@ -341,6 +341,7 @@ POST /networks/:networkAddress/path-info
 |value|string|YES|Transfer amount in smallest unit|
 |maxFees|string|NO|Upper bound for transfer fees|
 |maxHops|string|NO|Upper bound for hops in transfer path|
+|fee_payer|string|NO|Either `sender` or `receiver`|
 #### Example Request
 ```bash
 curl --header "Content-Type: application/json" \
@@ -841,7 +842,7 @@ The endpoint returns an object with the following fields:
 
 #### Example Response
 ```json
-{"identity": "0x43950642C8685ED8e3Fb89a5C5aeCb12862A87fd", "nextNonce": 0, "balance", "0"}
+{"identity": "0x43950642C8685ED8e3Fb89a5C5aeCb12862A87fd", "nextNonce": 0, "balance": "0"}
 ```
 
 ### Get identity information

--- a/relay/api/fields.py
+++ b/relay/api/fields.py
@@ -2,6 +2,7 @@ import hexbytes
 from webargs import ValidationError
 from marshmallow import fields
 from eth_utils import is_address, to_checksum_address
+from relay.network_graph.payment_path import FeePayer
 
 
 class Address(fields.String):
@@ -72,3 +73,18 @@ class HexEncodedBytes(fields.Field):
             raise ValidationError(
                 f"Could not parse hex-encoded bytes objects of attribute {attr}: {value}"
             )
+
+
+class FeePayerField(fields.Field):
+    def _serialize(self, value, attr, obj):
+
+        if isinstance(value, FeePayer):
+            # serialises into the value of the FeePayer enum
+            return value.value
+        else:
+            raise ValidationError("Value must be of type FeePayer")
+
+    def _deserialize(self, value, attr, data):
+
+        # deserialises into the FeePayer enum instance corresponding to the value
+        return FeePayer(value)

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -432,7 +432,7 @@ class Path(Resource):
         max_fees = args["maxFees"]
         max_hops = args["maxHops"]
 
-        cost, path = self.trustlines.currency_network_graphs[network_address].find_path(
+        cost, path = self.trustlines.currency_network_graphs[network_address].find_path_sender_pays_fees(
             source=source,
             target=target,
             value=value,

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -432,7 +432,7 @@ class Path(Resource):
         max_fees = args["maxFees"]
         max_hops = args["maxHops"]
 
-        cost, path = self.trustlines.currency_network_graphs[network_address].find_path_sender_pays_fees(
+        cost, path = self.trustlines.currency_network_graphs[network_address].find_transfer_path_sender_pays_fees(
             source=source,
             target=target,
             value=value,

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -466,6 +466,10 @@ class Path(Resource):
                 max_hops=max_hops,
                 timestamp=timestamp,
             )
+        else:
+            raise ValueError(
+                f"fee_payer has to be one of {[fee_payer.name for fee_payer in FeePayer]}: {fee_payer}"
+            )
 
         payment_path = _fill_estimated_gas_in_payment_path(
             self.trustlines,

--- a/relay/api/schemas.py
+++ b/relay/api/schemas.py
@@ -1,11 +1,12 @@
 from marshmallow import Schema, fields, post_load, ValidationError
 from marshmallow_oneofschema import OneOfSchema
 
-from .fields import Address, BigInteger, HexBytes, HexEncodedBytes
+from .fields import Address, BigInteger, HexBytes, HexEncodedBytes, FeePayerField
 
 from relay.blockchain.unw_eth_events import UnwEthEvent
 from relay.blockchain.exchange_events import ExchangeEvent
 from relay.blockchain.currency_network_events import CurrencyNetworkEvent
+from relay.network_graph.payment_path import PaymentPath
 from tldeploy import identity
 
 
@@ -191,7 +192,12 @@ class PaymentPathSchema(Schema):
     class Meta:
         strict = True
 
+    @post_load
+    def make_payment_path(self, data):
+        return PaymentPath(**data)
+
     fees = BigInteger(required=True, attribute="fee")
     path = fields.List(Address(), required=True)
-    estimatedGas = BigInteger(attribute="estimated_gas")
     value = BigInteger()
+    feePayer = FeePayerField(required=True, attribute="fee_payer")
+    estimatedGas = BigInteger(attribute="estimated_gas")

--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -222,9 +222,15 @@ class CurrencyNetworkProxy(Proxy):
             return 0
         source = payment_path.path[0]
         target = payment_path.path[-1]
-        return self._proxy.functions.transfer(
-            target, payment_path.value, payment_path.fee, payment_path.path[1:]
-        ).estimateGas({"from": source})
+
+        if payment_path.sender_pays_fees:
+            return self._proxy.functions.transfer(
+                target, payment_path.value, payment_path.fee, payment_path.path[1:]
+            ).estimateGas({"from": source})
+        else:
+            return self._proxy.functions.transferReceiverPays(
+                target, payment_path.value, payment_path.fee, payment_path.path[1:]
+            ).estimateGas({"from": source})
 
     def estimate_gas_for_close_trustline(self, source, other_party, max_fee, path):
         """estimate gas for doing a transfer for the given payment_path"""

--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -223,15 +223,20 @@ class CurrencyNetworkProxy(Proxy):
             return 0
         source = payment_path.path[0]
         target = payment_path.path[-1]
+        fee_payer = payment_path.fee_payer
 
-        if payment_path.fee_payer is FeePayer.SENDER:
+        if fee_payer is FeePayer.SENDER:
             return self._proxy.functions.transfer(
                 target, payment_path.value, payment_path.fee, payment_path.path[1:]
             ).estimateGas({"from": source})
-        elif payment_path.fee_payer is FeePayer.RECEIVER:
+        elif fee_payer is FeePayer.RECEIVER:
             return self._proxy.functions.transferReceiverPays(
                 target, payment_path.value, payment_path.fee, payment_path.path[1:]
             ).estimateGas({"from": source})
+        else:
+            raise ValueError(
+                f"fee_payer has to be one of {[fee_payer.name for fee_payer in FeePayer]}: {fee_payer}"
+            )
 
     def estimate_gas_for_close_trustline(self, source, other_party, max_fee, path):
         """estimate gas for doing a transfer for the given payment_path"""

--- a/relay/network_graph/graph.py
+++ b/relay/network_graph/graph.py
@@ -18,7 +18,7 @@ from relay.network_graph.trustline_data import (
     set_fees_outstanding,
 )
 
-from .payment_path import PaymentPath
+from .payment_path import PaymentPath, FeePayer
 
 from .fees import calculate_fees_reverse, calculate_fees, imbalance_generated
 from .interests import balance_with_interests
@@ -180,7 +180,7 @@ class SenderPaysCostAccumulatorSnapshot(alg.CostAccumulator):
         capacity_imbalance_fee_divisor,
         max_hops=None,
         max_fees=None,
-        ignore=None,
+        ignore=None
     ):
         if max_hops is None:
             max_hops = math.inf
@@ -277,7 +277,7 @@ class ReceiverPaysCostAccumulatorSnapshot(alg.CostAccumulator):
         capacity_imbalance_fee_divisor,
         max_hops=None,
         max_fees=None,
-        ignore=None,
+        ignore=None
     ):
         if max_hops is None:
             max_hops = math.inf
@@ -666,7 +666,7 @@ class CurrencyNetworkGraph(object):
         max_hops=None,
         max_fees=None,
         timestamp=0,
-        cost_accumulator_function,
+        cost_accumulator_function
     ):
 
         if value is None:
@@ -705,7 +705,7 @@ class CurrencyNetworkGraph(object):
             max_hops -= 2  # we compute the path without source at the beginning and end
 
         if balance == 0:
-            return PaymentPath(fee=0, path=[], value=0)
+            return PaymentPath(fee=0, path=[], value=0, fee_payer=FeePayer.SENDER)
         elif balance < 0:
             # payment looks like
             #
@@ -750,12 +750,14 @@ class CurrencyNetworkGraph(object):
             )  # don't check max_hops, we know we're below
             cost = cost_accumulator.compute_cost_for_path(self.graph, path)
         except nx.NetworkXNoPath:
-            return PaymentPath(fee=0, path=[], value=value)
+            return PaymentPath(fee=0, path=[], value=value, fee_payer=FeePayer.SENDER)
 
         if balance < 0:
             path.reverse()
 
-        return PaymentPath(fee=cost[0], path=path, value=value)
+        return PaymentPath(
+            fee=cost[0], path=path, value=value, fee_payer=FeePayer.SENDER
+        )
 
     def find_maximum_capacity_path(self, source, target, max_hops=None, timestamp=0):
         """

--- a/relay/network_graph/graph.py
+++ b/relay/network_graph/graph.py
@@ -18,7 +18,7 @@ from relay.network_graph.trustline_data import (
     set_fees_outstanding,
 )
 
-from .dijkstra_weighted import PaymentPath
+from .payment_path import PaymentPath
 
 from .fees import calculate_fees_reverse, calculate_fees, imbalance_generated
 from .interests import balance_with_interests
@@ -180,7 +180,7 @@ class SenderPaysCostAccumulatorSnapshot(alg.CostAccumulator):
         capacity_imbalance_fee_divisor,
         max_hops=None,
         max_fees=None,
-        ignore=None
+        ignore=None,
     ):
         if max_hops is None:
             max_hops = math.inf
@@ -277,7 +277,7 @@ class ReceiverPaysCostAccumulatorSnapshot(alg.CostAccumulator):
         capacity_imbalance_fee_divisor,
         max_hops=None,
         max_fees=None,
-        ignore=None
+        ignore=None,
     ):
         if max_hops is None:
             max_hops = math.inf
@@ -628,13 +628,7 @@ class CurrencyNetworkGraph(object):
         return output.getvalue()
 
     def find_transfer_path_sender_pays_fees(
-            self,
-            source,
-            target,
-            value=None,
-            max_hops=None,
-            max_fees=None,
-            timestamp=None,
+        self, source, target, value=None, max_hops=None, max_fees=None, timestamp=0
     ):
 
         cost, path = self._find_transfer_path(
@@ -650,13 +644,7 @@ class CurrencyNetworkGraph(object):
         return cost, list(reversed(path))
 
     def find_transfer_path_receiver_pays_fees(
-            self,
-            source,
-            target,
-            value=None,
-            max_hops=None,
-            max_fees=None,
-            timestamp=None,
+        self, source, target, value=None, max_hops=None, max_fees=None, timestamp=0
     ):
 
         return self._find_transfer_path(
@@ -670,15 +658,15 @@ class CurrencyNetworkGraph(object):
         )
 
     def _find_transfer_path(
-            self,
-            *,
-            source,
-            target,
-            value=None,
-            max_hops=None,
-            max_fees=None,
-            timestamp=None,
-            cost_accumulator_function,
+        self,
+        *,
+        source,
+        target,
+        value=None,
+        max_hops=None,
+        max_fees=None,
+        timestamp=0,
+        cost_accumulator_function,
     ):
 
         if value is None:
@@ -855,7 +843,9 @@ class CurrencyNetworkGraphForTesting(CurrencyNetworkGraph):
 
     def mediated_transfer(self, source, target, value, timestamp=0):
         """simulate mediated transfer off chain"""
-        cost, path = self.find_transfer_path_sender_pays_fees(source, target, value, timestamp=timestamp)
+        cost, path = self.find_transfer_path_sender_pays_fees(
+            source, target, value, timestamp=timestamp
+        )
         assert path[0] == source
         assert path[-1] == target
         return self.transfer_path(path, value, cost, timestamp=timestamp)

--- a/relay/network_graph/graph.py
+++ b/relay/network_graph/graph.py
@@ -627,9 +627,17 @@ class CurrencyNetworkGraph(object):
             )
         return output.getvalue()
 
-    def find_path_sender_pays_fees(self, source, target, value=None, max_hops=None, max_fees=None, timestamp=None):
+    def find_transfer_path_sender_pays_fees(
+            self,
+            source,
+            target,
+            value=None,
+            max_hops=None,
+            max_fees=None,
+            timestamp=None,
+    ):
 
-        cost, path = self._find_path(
+        cost, path = self._find_transfer_path(
             source=target,  # we are searching path from target to source, to accumulate fees correctly.
             target=source,
             value=value,
@@ -641,9 +649,17 @@ class CurrencyNetworkGraph(object):
 
         return cost, list(reversed(path))
 
-    def find_path_receiver_pays_fees(self, source, target, value=None, max_hops=None, max_fees=None, timestamp=None):
+    def find_transfer_path_receiver_pays_fees(
+            self,
+            source,
+            target,
+            value=None,
+            max_hops=None,
+            max_fees=None,
+            timestamp=None,
+    ):
 
-        return self._find_path(
+        return self._find_transfer_path(
             source=source,
             target=target,
             value=value,
@@ -653,7 +669,7 @@ class CurrencyNetworkGraph(object):
             cost_accumulator_function=ReceiverPaysCostAccumulatorSnapshot,
         )
 
-    def _find_path(
+    def _find_transfer_path(
             self,
             *,
             source,
@@ -839,7 +855,7 @@ class CurrencyNetworkGraphForTesting(CurrencyNetworkGraph):
 
     def mediated_transfer(self, source, target, value, timestamp=0):
         """simulate mediated transfer off chain"""
-        cost, path = self.find_path_sender_pays_fees(source, target, value, timestamp=timestamp)
+        cost, path = self.find_transfer_path_sender_pays_fees(source, target, value, timestamp=timestamp)
         assert path[0] == source
         assert path[-1] == target
         return self.transfer_path(path, value, cost, timestamp=timestamp)

--- a/relay/network_graph/payment_path.py
+++ b/relay/network_graph/payment_path.py
@@ -7,4 +7,5 @@ class PaymentPath:
     fee: int
     path: List
     value: int
+    sender_pays_fees: bool = attr.ib(default=True)
     estimated_gas: int = attr.ib(default=None)

--- a/relay/network_graph/payment_path.py
+++ b/relay/network_graph/payment_path.py
@@ -1,5 +1,11 @@
 from typing import List
 import attr
+from enum import Enum
+
+
+class FeePayer(Enum):
+    SENDER = "sender"
+    RECEIVER = "receiver"
 
 
 @attr.s(auto_attribs=True)
@@ -7,5 +13,5 @@ class PaymentPath:
     fee: int
     path: List
     value: int
-    sender_pays_fees: bool = attr.ib(default=True)
+    fee_payer: FeePayer
     estimated_gas: int = attr.ib(default=None)

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -61,22 +61,22 @@ def fresh_community(currency_network):
 def test_path(community_with_trustlines, accounts):
     community = community_with_trustlines
     A, B, C, D, E, *rest = accounts
-    cost, path = community.find_path_sender_pays_fees(A, B, 10)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, B, 10)
     assert path == [A, B]
-    cost, path = community.find_path_sender_pays_fees(A, D, 10)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, D, 10)
     assert path == [A, E, D]
 
 
 def test_no_capacity(community_with_trustlines, accounts):
     community = community_with_trustlines
     A, B, C, D, E, *rest = accounts
-    cost, path = community.find_path_sender_pays_fees(A, E, 550)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, E, 550)
     assert path == [A, E]
-    cost, path = community.find_path_sender_pays_fees(A, E, 551)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, E, 551)
     assert path == []
-    cost, path = community.find_path_sender_pays_fees(E, A, 500)
+    cost, path = community.find_transfer_path_sender_pays_fees(E, A, 500)
     assert path == [E, A]
-    cost, path = community.find_path_sender_pays_fees(E, A, 501)
+    cost, path = community.find_transfer_path_sender_pays_fees(E, A, 501)
     assert path == []
 
 

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -61,22 +61,22 @@ def fresh_community(currency_network):
 def test_path(community_with_trustlines, accounts):
     community = community_with_trustlines
     A, B, C, D, E, *rest = accounts
-    cost, path = community.find_path(A, B, 10)
+    cost, path = community.find_path_sender_pays_fees(A, B, 10)
     assert path == [A, B]
-    cost, path = community.find_path(A, D, 10)
+    cost, path = community.find_path_sender_pays_fees(A, D, 10)
     assert path == [A, E, D]
 
 
 def test_no_capacity(community_with_trustlines, accounts):
     community = community_with_trustlines
     A, B, C, D, E, *rest = accounts
-    cost, path = community.find_path(A, E, 550)
+    cost, path = community.find_path_sender_pays_fees(A, E, 550)
     assert path == [A, E]
-    cost, path = community.find_path(A, E, 551)
+    cost, path = community.find_path_sender_pays_fees(A, E, 551)
     assert path == []
-    cost, path = community.find_path(E, A, 500)
+    cost, path = community.find_path_sender_pays_fees(E, A, 500)
     assert path == [E, A]
-    cost, path = community.find_path(E, A, 501)
+    cost, path = community.find_path_sender_pays_fees(E, A, 501)
     assert path == []
 
 

--- a/tests/unit/api/test_schemas.py
+++ b/tests/unit/api/test_schemas.py
@@ -7,6 +7,7 @@ from hexbytes import HexBytes
 from tldeploy import identity
 from relay.api import schemas
 from marshmallow import ValidationError
+from relay.network_graph.payment_path import PaymentPath, FeePayer
 
 
 a_valid_meta_transaction = identity.MetaTransaction(
@@ -92,3 +93,28 @@ def test_load_meta_transaction_valid_values(values):
     dumped = schemas.MetaTransactionSchema().dump(a_valid_meta_transaction).data
     dumped.update(values)
     assert not schemas.MetaTransactionSchema().load(dumped).errors
+
+
+@pytest.fixture(params=[FeePayer.SENDER, FeePayer.RECEIVER])
+def payment_path(request):
+
+    cost = 1
+    path = []
+    value = 1
+    fee_payer = request.param
+    estimated_gas = 0
+
+    return PaymentPath(
+        cost, path, value, fee_payer=fee_payer, estimated_gas=estimated_gas
+    )
+
+
+def test_payment_path_roundtrip(payment_path):
+
+    dumped = schemas.PaymentPathSchema().dump(payment_path).data
+    print("DUMPED", dumped)
+
+    loaded = schemas.PaymentPathSchema().load(dumped).data
+    print("LOADED", loaded)
+
+    assert loaded == payment_path

--- a/tests/unit/network_graph/test_find_path.py
+++ b/tests/unit/network_graph/test_find_path.py
@@ -40,7 +40,7 @@ def sanity_check_fees(graph, cost_path):
 
 
 def test_find_path_cost_wrong_bug_issue_219(graph):
-    """our old implementation of find_path_sender_pays_fees failed to compute the correct cost
+    """our old implementation of find_transfer_path_sender_pays_fees failed to compute the correct cost
     for some paths
 
     This is a test for https://github.com/trustlines-network/relay/issues/219"""

--- a/tests/unit/network_graph/test_find_path.py
+++ b/tests/unit/network_graph/test_find_path.py
@@ -40,7 +40,7 @@ def sanity_check_fees(graph, cost_path):
 
 
 def test_find_path_cost_wrong_bug_issue_219(graph):
-    """our old implementation of find_path failed to compute the correct cost
+    """our old implementation of find_path_sender_pays_fees failed to compute the correct cost
     for some paths
 
     This is a test for https://github.com/trustlines-network/relay/issues/219"""

--- a/tests/unit/network_graph/test_graph.py
+++ b/tests/unit/network_graph/test_graph.py
@@ -5,7 +5,7 @@ from relay.blockchain.currency_network_proxy import Trustline
 from relay.network_graph.graph import (
     CurrencyNetworkGraphForTesting as CurrencyNetworkGraph,
 )
-from relay.network_graph.payment_path import PaymentPath
+from relay.network_graph.payment_path import PaymentPath, FeePayer
 from tests.unit.network_graph.conftest import addresses
 
 A, B, C, D, E, F, G, H = addresses
@@ -168,7 +168,9 @@ def test_close_trustline_no_cost_exact_amount(
     payment_path = complex_community_with_trustlines_and_fees.close_trustline_path_triangulation(
         now, A, B
     )
-    assert payment_path == PaymentPath(fee=0, path=[A, C, D, B, A], value=10000)
+    assert payment_path == PaymentPath(
+        fee=0, path=[A, C, D, B, A], value=10000, fee_payer=FeePayer.SENDER
+    )
 
 
 def test_close_trustline_not_enough_capacity(
@@ -185,7 +187,9 @@ def test_close_trustline_not_enough_capacity(
     payment_path = complex_community_with_trustlines_and_fees.close_trustline_path_triangulation(
         now, A, B
     )
-    assert payment_path == PaymentPath(fee=0, path=[], value=100000)
+    assert payment_path == PaymentPath(
+        fee=0, path=[], value=100000, fee_payer=FeePayer.SENDER
+    )
 
 
 def test_close_trustline_first_edge_insufficient_capacity(
@@ -793,7 +797,9 @@ def test_close_trustline_zero_balance(complex_community_with_trustlines_and_fees
     result = complex_community_with_trustlines_and_fees.close_trustline_path_triangulation(
         timestamp=int(time.time()), source=C, target=H
     )
-    assert result == PaymentPath(fee=0, path=[], value=0, estimated_gas=None)
+    assert result == PaymentPath(
+        fee=0, path=[], value=0, estimated_gas=None, fee_payer=FeePayer.SENDER
+    )
 
 
 def test_close_trustline_positive_balance(complex_community_with_trustlines_and_fees):
@@ -803,7 +809,11 @@ def test_close_trustline_positive_balance(complex_community_with_trustlines_and_
         timestamp=int(time.time()), source=C, target=H
     )
     assert result == PaymentPath(
-        fee=198, path=[C, H, G, F, E, D, C], value=5000, estimated_gas=None
+        fee=198,
+        path=[C, H, G, F, E, D, C],
+        value=5000,
+        estimated_gas=None,
+        fee_payer=FeePayer.SENDER,
     )
 
 
@@ -814,7 +824,11 @@ def test_close_trustline_negative_balance(complex_community_with_trustlines_and_
         timestamp=int(time.time()), source=C, target=H
     )
     assert result == PaymentPath(
-        fee=261, path=[C, D, E, F, G, H, C], value=5000, estimated_gas=None
+        fee=261,
+        path=[C, D, E, F, G, H, C],
+        value=5000,
+        estimated_gas=None,
+        fee_payer=FeePayer.SENDER,
     )
 
 
@@ -832,7 +846,11 @@ def test_close_trustline_with_cost_exact_amount(
         timestamp=int(time.time()), source=A, target=B
     )
     assert result == PaymentPath(
-        fee=309, path=[A, C, D, B, A], value=10000, estimated_gas=None
+        fee=309,
+        path=[A, C, D, B, A],
+        value=10000,
+        estimated_gas=None,
+        fee_payer=FeePayer.SENDER,
     )
 
 
@@ -843,6 +861,16 @@ def test_close_trustline_multi(complex_community_with_trustlines_and_fees):
         timestamp=int(time.time()), source=A, target=H
     )
     assert result in [
-        PaymentPath(fee=315, path=[A, B, D, E, F, G, H, A], value=5000),
-        PaymentPath(fee=315, path=[A, C, D, E, F, G, H, A], value=5000),
+        PaymentPath(
+            fee=315,
+            path=[A, B, D, E, F, G, H, A],
+            value=5000,
+            fee_payer=FeePayer.SENDER,
+        ),
+        PaymentPath(
+            fee=315,
+            path=[A, C, D, E, F, G, H, A],
+            value=5000,
+            fee_payer=FeePayer.SENDER,
+        ),
     ]

--- a/tests/unit/network_graph/test_graph.py
+++ b/tests/unit/network_graph/test_graph.py
@@ -813,7 +813,7 @@ def test_close_trustline_positive_balance(complex_community_with_trustlines_and_
         path=[C, H, G, F, E, D, C],
         value=5000,
         estimated_gas=None,
-        fee_payer=FeePayer.SENDER,
+        fee_payer=FeePayer.RECEIVER,
     )
 
 

--- a/tests/unit/network_graph/test_graph.py
+++ b/tests/unit/network_graph/test_graph.py
@@ -14,9 +14,9 @@ A, B, C, D, E, F, G, H = addresses
 
 def assert_maximum_path(community, max_path, max_amount):
     """Asserts that the found path and amount is indeed the maximum"""
-    fee, path = community.find_path(max_path[0], max_path[-1], max_amount)
+    fee, path = community.find_path_sender_pays_fees(max_path[0], max_path[-1], max_amount)
     assert path == max_path
-    fee, path = community.find_path(max_path[0], max_path[-1], max_amount + 1)
+    fee, path = community.find_path_sender_pays_fees(max_path[0], max_path[-1], max_amount + 1)
     assert path == []
 
 
@@ -89,6 +89,17 @@ def complex_community_with_trustlines_and_fees_configurable_balances(
     for user, counter_party, balance in request.param:
         complex_community_with_trustlines.update_balance(user, counter_party, balance)
     return complex_community_with_trustlines
+
+
+@pytest.fixture(
+    params=[
+        CurrencyNetworkGraph.find_path_sender_pays_fees,
+        CurrencyNetworkGraph.find_path_receiver_pays_fees
+    ]
+)
+def find_path_sender_then_receiver_pays(community_with_trustlines, request):
+
+    return request.param
 
 
 def test_users(community_with_trustlines):
@@ -465,43 +476,51 @@ def test_mediated_transfer(community_with_trustlines):
     assert community.get_account_sum(B, C).balance == -50
 
 
-def test_path(community_with_trustlines):
+def test_path(community_with_trustlines, find_path_sender_then_receiver_pays):
+    find_path = find_path_sender_then_receiver_pays
     community = community_with_trustlines
-    cost, path = community.find_path(A, B, 10)
+
+    cost, path = find_path(community, A, B, 10)
     assert path == [A, B]
     assert cost == 0
-    cost, path = community.find_path(A, D, 10)
+    cost, path = find_path(community, A, D, 10)
     assert path == [A, E, D]
     assert cost == 0
 
 
-def test_no_path(community_with_trustlines):
+def test_no_path(community_with_trustlines, find_path_sender_then_receiver_pays):
     community = community_with_trustlines
+    find_path = find_path_sender_then_receiver_pays
+
     community.update_trustline(F, G, 100, 0)
-    cost, path = community.find_path(G, F, 10)
+    cost, path = find_path(community, G, F, 10)
     assert path == [G, F]
-    cost, path = community.find_path(A, G, 10)  # no path at all
+    cost, path = find_path(community, A, G, 10)  # no path at all
     assert path == []
 
 
-def test_no_capacity(community_with_trustlines):
+def test_no_capacity(community_with_trustlines, find_path_sender_then_receiver_pays):
     community = community_with_trustlines
-    cost, path = community.find_path(A, E, 550)
+    find_path = find_path_sender_then_receiver_pays
+
+    cost, path = find_path(community, A, E, 550)
     assert path == [A, E]
-    cost, path = community.find_path(A, E, 551)
+    cost, path = find_path(community, A, E, 551)
     assert path == []
-    cost, path = community.find_path(E, A, 500)
+    cost, path = find_path(community, E, A, 500)
     assert path == [E, A]
-    cost, path = community.find_path(E, A, 501)
+    cost, path = find_path(community, E, A, 501)
     assert path == []
 
 
-def test_no_direction(community_with_trustlines):
+def test_no_direction(community_with_trustlines, find_path_sender_then_receiver_pays):
     community = community_with_trustlines
+    find_path = find_path_sender_then_receiver_pays
+
     community.update_trustline(F, G, 100, 0)
-    cost, path = community.find_path(G, F, 10)
+    cost, path = find_path(community_with_trustlines, G, F, 10)
     assert path == [G, F]
-    cost, path = community.find_path(F, G, 10)  # no creditline in this direction
+    cost, path = find_path(community_with_trustlines, F, G, 10)  # no creditline in this direction
     assert path == []
 
 
@@ -515,44 +534,51 @@ def test_valid_path_raises_no_value_error(complex_community_with_trustlines_and_
     complex_community_with_trustlines_and_fees.update_balance(B, D, -10000)
     complex_community_with_trustlines_and_fees.update_balance(C, D, 10000)
     complex_community_with_trustlines_and_fees.update_balance(D, E, 0)
-    cost, path = complex_community_with_trustlines_and_fees.find_path(
-        E, A, 10000
-    )  # should not raise ValueError
+    # should not raise ValueError
+    cost, path = complex_community_with_trustlines_and_fees.find_path_sender_pays_fees(
+        E,
+        A,
+        10000,
+    )
 
 
-def test_max_hops(community_with_trustlines):
+def test_max_hops(community_with_trustlines, find_path_sender_then_receiver_pays):
     community = community_with_trustlines
-    cost, path = community.find_path(A, D, 10)
+    find_path = find_path_sender_then_receiver_pays
+
+    cost, path = find_path(community, A, D, 10)
     assert path == [A, E, D]
-    cost, path = community.find_path(A, D, 10, max_hops=1)
+    cost, path = find_path(community, A, D, 10, max_hops=1)
     assert path == []
 
 
 def test_send_back(community_with_trustlines):
     community = community_with_trustlines
+
     assert community.get_account_sum(A, B).balance == 0
-    assert community.find_path(B, A, 120)[1] == [B, C, D, E, A]
-    assert community.find_path(A, B, 120)[1] == [A, B]
+    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
     community.mediated_transfer(A, B, 120)
     assert community.get_account_sum(B, A).balance == 120
-    assert community.find_path(B, A, 120)[1] == [B, A]
-    assert community.find_path(A, B, 120)[1] == [A, E, D, C, B]
+    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, A]
+    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, E, D, C, B]
     community.mediated_transfer(B, A, 120)
     assert community.get_account_sum(A, B).balance == 0
 
 
 def test_send_more(community_with_trustlines):
     community = community_with_trustlines
+
     assert community.get_account_sum(A, B).balance == 0
     assert community.get_account_sum(A, B).creditline_left_received == 150
     assert community.get_account_sum(B, A).creditline_left_received == 100
-    assert community.find_path(A, B, 120)[1] == [A, B]
-    assert community.find_path(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
+    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
     community.mediated_transfer(A, B, 120)
     assert community.get_account_sum(B, A).balance == 120
     assert community.get_account_sum(B, A).creditline_left_received == 220
-    assert community.find_path(A, B, 200)[1] == [A, E, D, C, B]
-    assert community.find_path(B, A, 200)[1] == [B, A]
+    assert community.find_path_sender_pays_fees(A, B, 200)[1] == [A, E, D, C, B]
+    assert community.find_path_sender_pays_fees(B, A, 200)[1] == [B, A]
     community.mediated_transfer(B, A, 200)
     assert community.get_account_sum(A, B).balance == 80
 
@@ -562,14 +588,14 @@ def test_send_more_nopath(community_with_trustlines):
     assert community.get_account_sum(A, B).balance == 0
     assert community.get_account_sum(A, B).creditline_left_received == 150
     assert community.get_account_sum(B, A).creditline_left_received == 100
-    assert community.find_path(A, B, 160)[1] == [A, E, D, C, B]
-    assert community.find_path(B, A, 160)[1] == [B, C, D, E, A]
+    assert community.find_path_sender_pays_fees(A, B, 160)[1] == [A, E, D, C, B]
+    assert community.find_path_sender_pays_fees(B, A, 160)[1] == [B, C, D, E, A]
     community.mediated_transfer(A, B, 50)
     assert community.get_account_sum(B, A).balance == 50
     assert community.get_account_sum(A, B).creditline_left_received == 100
     assert community.get_account_sum(B, A).creditline_left_received == 150
-    assert community.find_path(A, B, 160)[1] == [A, E, D, C, B]
-    assert community.find_path(B, A, 160)[1] == [B, C, D, E, A]
+    assert community.find_path_sender_pays_fees(A, B, 160)[1] == [A, E, D, C, B]
+    assert community.find_path_sender_pays_fees(B, A, 160)[1] == [B, C, D, E, A]
     community.mediated_transfer(B, A, 50)
     assert community.get_account_sum(A, B).balance == 0
 
@@ -604,46 +630,71 @@ def test_mediated_transfer_with_fees(community_with_trustlines_and_fees):
     assert community.get_account_sum(B, C).balance == -50
 
 
-def test_path_with_fees(community_with_trustlines_and_fees):
+def test_path_with_fees_sender_pays(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path(A, B, 10)
+    cost, path = community.find_path_sender_pays_fees(A, B, 10)
     assert path == [A, B]
     assert cost == 0
-    cost, path = community.find_path(A, D, 10)
+    cost, path = community.find_path_sender_pays_fees(A, D, 10)
     assert path == [A, E, D]
     assert cost == 1
 
 
+def test_path_with_fees_receiver_pays(community_with_trustlines_and_fees):
+    community = community_with_trustlines_and_fees
+    cost, path = community.find_path_receiver_pays_fees(A, B, 10)
+    assert path == [A, B]
+    assert cost == 0
+    cost, path = community.find_path_receiver_pays_fees(A, D, 10)
+    assert path == [A, E, D]
+    assert cost == 1
+
+
+def test_path_fee_symmetry_sanity(complex_community_with_trustlines_and_fees):
+    community = complex_community_with_trustlines_and_fees
+
+    sender_pays = 50000
+
+    cost, path = community.find_path_receiver_pays_fees(A, H, sender_pays)
+    assert path == [A, B, D, E, F, G, H]
+    assert cost == 2453
+
+    receiver_receives = sender_pays - cost
+    cost, path = community.find_path_sender_pays_fees(A, H, receiver_receives)
+    assert path == [A, B, D, E, F, G, H]
+    assert cost == 2453
+
+
 def test_max_fees(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path(A, D, 110)
+    cost, path = community.find_path_sender_pays_fees(A, D, 110)
     assert path == [A, E, D]
     assert cost == 2
-    cost, path = community.find_path(A, D, 110, max_fees=1)
+    cost, path = community.find_path_sender_pays_fees(A, D, 110, max_fees=1)
     assert path == []
 
 
 def test_no_capacity_with_fees(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path(A, E, 550)
+    cost, path = community.find_path_sender_pays_fees(A, E, 550)
     assert path == [A, E]
-    cost, path = community.find_path(A, E, 551)
+    cost, path = community.find_path_sender_pays_fees(A, E, 551)
     assert path == []
-    cost, path = community.find_path(E, A, 500)
+    cost, path = community.find_path_sender_pays_fees(E, A, 500)
     assert path == [E, A]
-    cost, path = community.find_path(E, A, 501)
+    cost, path = community.find_path_sender_pays_fees(E, A, 501)
     assert path == []
 
 
 def test_send_back_with_fees(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
     assert community.get_account_sum(A, B).balance == 0
-    assert community.find_path(B, A, 120)[1] == [B, C, D, E, A]
-    assert community.find_path(A, B, 120)[1] == [A, B]
+    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
     assert community.mediated_transfer(A, B, 120) == 0
     assert community.get_account_sum(B, A).balance == 120
-    assert community.find_path(B, A, 120)[1] == [B, A]
-    assert community.find_path(A, B, 120)[1] == [A, E, D, C, B]
+    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, A]
+    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, E, D, C, B]
     assert community.mediated_transfer(B, A, 120) == 0
     assert community.get_account_sum(A, B).balance == 0
 
@@ -653,13 +704,13 @@ def test_send_more_with_fees(community_with_trustlines_and_fees):
     assert community.get_account_sum(A, B).balance == 0
     assert community.get_account_sum(A, B).creditline_left_received == 150
     assert community.get_account_sum(B, A).creditline_left_received == 100
-    assert community.find_path(A, B, 120)[1] == [A, B]
-    assert community.find_path(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
+    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
     assert community.mediated_transfer(A, B, 120) == 0
     assert community.get_account_sum(B, A).balance == 120 + 0
     assert community.get_account_sum(B, A).creditline_left_received == 220 + 0
-    assert community.find_path(A, B, 201)[1] == []
-    assert community.find_path(B, A, 200)[1] == [B, A]
+    assert community.find_path_sender_pays_fees(A, B, 201)[1] == []
+    assert community.find_path_sender_pays_fees(B, A, 200)[1] == [B, A]
     assert community.mediated_transfer(B, A, 200) == 0
     assert community.get_account_sum(A, B).balance == 80
 

--- a/tests/unit/network_graph/test_graph.py
+++ b/tests/unit/network_graph/test_graph.py
@@ -14,9 +14,9 @@ A, B, C, D, E, F, G, H = addresses
 
 def assert_maximum_path(community, max_path, max_amount):
     """Asserts that the found path and amount is indeed the maximum"""
-    fee, path = community.find_path_sender_pays_fees(max_path[0], max_path[-1], max_amount)
+    fee, path = community.find_transfer_path_sender_pays_fees(max_path[0], max_path[-1], max_amount)
     assert path == max_path
-    fee, path = community.find_path_sender_pays_fees(max_path[0], max_path[-1], max_amount + 1)
+    fee, path = community.find_transfer_path_sender_pays_fees(max_path[0], max_path[-1], max_amount + 1)
     assert path == []
 
 
@@ -93,11 +93,11 @@ def complex_community_with_trustlines_and_fees_configurable_balances(
 
 @pytest.fixture(
     params=[
-        CurrencyNetworkGraph.find_path_sender_pays_fees,
-        CurrencyNetworkGraph.find_path_receiver_pays_fees
+        CurrencyNetworkGraph.find_transfer_path_sender_pays_fees,
+        CurrencyNetworkGraph.find_transfer_path_receiver_pays_fees
     ]
 )
-def find_path_sender_then_receiver_pays(community_with_trustlines, request):
+def parametrised_find_transfer_path_function(community_with_trustlines, request):
 
     return request.param
 
@@ -476,8 +476,8 @@ def test_mediated_transfer(community_with_trustlines):
     assert community.get_account_sum(B, C).balance == -50
 
 
-def test_path(community_with_trustlines, find_path_sender_then_receiver_pays):
-    find_path = find_path_sender_then_receiver_pays
+def test_path(community_with_trustlines, parametrised_find_transfer_path_function):
+    find_path = parametrised_find_transfer_path_function
     community = community_with_trustlines
 
     cost, path = find_path(community, A, B, 10)
@@ -488,9 +488,9 @@ def test_path(community_with_trustlines, find_path_sender_then_receiver_pays):
     assert cost == 0
 
 
-def test_no_path(community_with_trustlines, find_path_sender_then_receiver_pays):
+def test_no_path(community_with_trustlines, parametrised_find_transfer_path_function):
     community = community_with_trustlines
-    find_path = find_path_sender_then_receiver_pays
+    find_path = parametrised_find_transfer_path_function
 
     community.update_trustline(F, G, 100, 0)
     cost, path = find_path(community, G, F, 10)
@@ -499,9 +499,9 @@ def test_no_path(community_with_trustlines, find_path_sender_then_receiver_pays)
     assert path == []
 
 
-def test_no_capacity(community_with_trustlines, find_path_sender_then_receiver_pays):
+def test_no_capacity(community_with_trustlines, parametrised_find_transfer_path_function):
     community = community_with_trustlines
-    find_path = find_path_sender_then_receiver_pays
+    find_path = parametrised_find_transfer_path_function
 
     cost, path = find_path(community, A, E, 550)
     assert path == [A, E]
@@ -513,9 +513,9 @@ def test_no_capacity(community_with_trustlines, find_path_sender_then_receiver_p
     assert path == []
 
 
-def test_no_direction(community_with_trustlines, find_path_sender_then_receiver_pays):
+def test_no_direction(community_with_trustlines, parametrised_find_transfer_path_function):
     community = community_with_trustlines
-    find_path = find_path_sender_then_receiver_pays
+    find_path = parametrised_find_transfer_path_function
 
     community.update_trustline(F, G, 100, 0)
     cost, path = find_path(community_with_trustlines, G, F, 10)
@@ -535,16 +535,16 @@ def test_valid_path_raises_no_value_error(complex_community_with_trustlines_and_
     complex_community_with_trustlines_and_fees.update_balance(C, D, 10000)
     complex_community_with_trustlines_and_fees.update_balance(D, E, 0)
     # should not raise ValueError
-    cost, path = complex_community_with_trustlines_and_fees.find_path_sender_pays_fees(
+    cost, path = complex_community_with_trustlines_and_fees.find_transfer_path_sender_pays_fees(
         E,
         A,
         10000,
     )
 
 
-def test_max_hops(community_with_trustlines, find_path_sender_then_receiver_pays):
+def test_max_hops(community_with_trustlines, parametrised_find_transfer_path_function):
     community = community_with_trustlines
-    find_path = find_path_sender_then_receiver_pays
+    find_path = parametrised_find_transfer_path_function
 
     cost, path = find_path(community, A, D, 10)
     assert path == [A, E, D]
@@ -556,12 +556,12 @@ def test_send_back(community_with_trustlines):
     community = community_with_trustlines
 
     assert community.get_account_sum(A, B).balance == 0
-    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
-    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 120)[1] == [A, B]
     community.mediated_transfer(A, B, 120)
     assert community.get_account_sum(B, A).balance == 120
-    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, A]
-    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, E, D, C, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 120)[1] == [B, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 120)[1] == [A, E, D, C, B]
     community.mediated_transfer(B, A, 120)
     assert community.get_account_sum(A, B).balance == 0
 
@@ -572,13 +572,13 @@ def test_send_more(community_with_trustlines):
     assert community.get_account_sum(A, B).balance == 0
     assert community.get_account_sum(A, B).creditline_left_received == 150
     assert community.get_account_sum(B, A).creditline_left_received == 100
-    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
-    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 120)[1] == [A, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
     community.mediated_transfer(A, B, 120)
     assert community.get_account_sum(B, A).balance == 120
     assert community.get_account_sum(B, A).creditline_left_received == 220
-    assert community.find_path_sender_pays_fees(A, B, 200)[1] == [A, E, D, C, B]
-    assert community.find_path_sender_pays_fees(B, A, 200)[1] == [B, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 200)[1] == [A, E, D, C, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 200)[1] == [B, A]
     community.mediated_transfer(B, A, 200)
     assert community.get_account_sum(A, B).balance == 80
 
@@ -588,14 +588,14 @@ def test_send_more_nopath(community_with_trustlines):
     assert community.get_account_sum(A, B).balance == 0
     assert community.get_account_sum(A, B).creditline_left_received == 150
     assert community.get_account_sum(B, A).creditline_left_received == 100
-    assert community.find_path_sender_pays_fees(A, B, 160)[1] == [A, E, D, C, B]
-    assert community.find_path_sender_pays_fees(B, A, 160)[1] == [B, C, D, E, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 160)[1] == [A, E, D, C, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 160)[1] == [B, C, D, E, A]
     community.mediated_transfer(A, B, 50)
     assert community.get_account_sum(B, A).balance == 50
     assert community.get_account_sum(A, B).creditline_left_received == 100
     assert community.get_account_sum(B, A).creditline_left_received == 150
-    assert community.find_path_sender_pays_fees(A, B, 160)[1] == [A, E, D, C, B]
-    assert community.find_path_sender_pays_fees(B, A, 160)[1] == [B, C, D, E, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 160)[1] == [A, E, D, C, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 160)[1] == [B, C, D, E, A]
     community.mediated_transfer(B, A, 50)
     assert community.get_account_sum(A, B).balance == 0
 
@@ -632,20 +632,20 @@ def test_mediated_transfer_with_fees(community_with_trustlines_and_fees):
 
 def test_path_with_fees_sender_pays(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path_sender_pays_fees(A, B, 10)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, B, 10)
     assert path == [A, B]
     assert cost == 0
-    cost, path = community.find_path_sender_pays_fees(A, D, 10)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, D, 10)
     assert path == [A, E, D]
     assert cost == 1
 
 
 def test_path_with_fees_receiver_pays(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path_receiver_pays_fees(A, B, 10)
+    cost, path = community.find_transfer_path_receiver_pays_fees(A, B, 10)
     assert path == [A, B]
     assert cost == 0
-    cost, path = community.find_path_receiver_pays_fees(A, D, 10)
+    cost, path = community.find_transfer_path_receiver_pays_fees(A, D, 10)
     assert path == [A, E, D]
     assert cost == 1
 
@@ -655,46 +655,46 @@ def test_path_fee_symmetry_sanity(complex_community_with_trustlines_and_fees):
 
     sender_pays = 50000
 
-    cost, path = community.find_path_receiver_pays_fees(A, H, sender_pays)
+    cost, path = community.find_transfer_path_receiver_pays_fees(A, H, sender_pays)
     assert path == [A, B, D, E, F, G, H]
     assert cost == 2453
 
     receiver_receives = sender_pays - cost
-    cost, path = community.find_path_sender_pays_fees(A, H, receiver_receives)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, H, receiver_receives)
     assert path == [A, B, D, E, F, G, H]
     assert cost == 2453
 
 
 def test_max_fees(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path_sender_pays_fees(A, D, 110)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, D, 110)
     assert path == [A, E, D]
     assert cost == 2
-    cost, path = community.find_path_sender_pays_fees(A, D, 110, max_fees=1)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, D, 110, max_fees=1)
     assert path == []
 
 
 def test_no_capacity_with_fees(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
-    cost, path = community.find_path_sender_pays_fees(A, E, 550)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, E, 550)
     assert path == [A, E]
-    cost, path = community.find_path_sender_pays_fees(A, E, 551)
+    cost, path = community.find_transfer_path_sender_pays_fees(A, E, 551)
     assert path == []
-    cost, path = community.find_path_sender_pays_fees(E, A, 500)
+    cost, path = community.find_transfer_path_sender_pays_fees(E, A, 500)
     assert path == [E, A]
-    cost, path = community.find_path_sender_pays_fees(E, A, 501)
+    cost, path = community.find_transfer_path_sender_pays_fees(E, A, 501)
     assert path == []
 
 
 def test_send_back_with_fees(community_with_trustlines_and_fees):
     community = community_with_trustlines_and_fees
     assert community.get_account_sum(A, B).balance == 0
-    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
-    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 120)[1] == [A, B]
     assert community.mediated_transfer(A, B, 120) == 0
     assert community.get_account_sum(B, A).balance == 120
-    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, A]
-    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, E, D, C, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 120)[1] == [B, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 120)[1] == [A, E, D, C, B]
     assert community.mediated_transfer(B, A, 120) == 0
     assert community.get_account_sum(A, B).balance == 0
 
@@ -704,13 +704,13 @@ def test_send_more_with_fees(community_with_trustlines_and_fees):
     assert community.get_account_sum(A, B).balance == 0
     assert community.get_account_sum(A, B).creditline_left_received == 150
     assert community.get_account_sum(B, A).creditline_left_received == 100
-    assert community.find_path_sender_pays_fees(A, B, 120)[1] == [A, B]
-    assert community.find_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 120)[1] == [A, B]
+    assert community.find_transfer_path_sender_pays_fees(B, A, 120)[1] == [B, C, D, E, A]
     assert community.mediated_transfer(A, B, 120) == 0
     assert community.get_account_sum(B, A).balance == 120 + 0
     assert community.get_account_sum(B, A).creditline_left_received == 220 + 0
-    assert community.find_path_sender_pays_fees(A, B, 201)[1] == []
-    assert community.find_path_sender_pays_fees(B, A, 200)[1] == [B, A]
+    assert community.find_transfer_path_sender_pays_fees(A, B, 201)[1] == []
+    assert community.find_transfer_path_sender_pays_fees(B, A, 200)[1] == [B, A]
     assert community.mediated_transfer(B, A, 200) == 0
     assert community.get_account_sum(A, B).balance == 80
 

--- a/tests/unit/network_graph/test_interests.py
+++ b/tests/unit/network_graph/test_interests.py
@@ -172,7 +172,9 @@ def test_interests_path_from_A_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        A, B, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == [A, B]
 
 
@@ -194,7 +196,9 @@ def test_interests_path_from_A_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        A, B, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == []
 
 
@@ -216,7 +220,9 @@ def test_interests_path_from_A_balance_positive_irrelevant_interests(
 ):
     # B owes to A
     # 1% interest given by B to A
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        A, B, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == [A, B]
 
 
@@ -238,7 +244,9 @@ def test_interests_path_from_A_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        A, B, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == [A, B]
 
 
@@ -260,7 +268,9 @@ def test_interests_path_from_B_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        B, A, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == []
 
 
@@ -282,7 +292,9 @@ def test_interests_path_from_B_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        B, A, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == [B, A]
 
 
@@ -304,7 +316,9 @@ def test_interests_path_from_B_balance_positive_irrelevant_interests(
 ):
     # B owes to A
     # 1% interest given by B to A
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        B, A, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == [B, A]
 
 
@@ -326,5 +340,7 @@ def test_interests_path_from_B_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(
+        B, A, 100, timestamp=SECONDS_PER_YEAR
+    )
     assert path == [B, A]

--- a/tests/unit/network_graph/test_interests.py
+++ b/tests/unit/network_graph/test_interests.py
@@ -172,7 +172,7 @@ def test_interests_path_from_A_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -194,7 +194,7 @@ def test_interests_path_from_A_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
@@ -216,8 +216,7 @@ def test_interests_path_from_A_balance_positive_irrelevant_interests(
 ):
     # B owes to A
     # 1% interest given by B to A
-
-    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -239,7 +238,7 @@ def test_interests_path_from_A_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -261,7 +260,7 @@ def test_interests_path_from_B_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
@@ -283,7 +282,7 @@ def test_interests_path_from_B_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
@@ -305,7 +304,7 @@ def test_interests_path_from_B_balance_positive_irrelevant_interests(
 ):
     # B owes to A
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
@@ -327,5 +326,5 @@ def test_interests_path_from_B_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_transfer_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]

--- a/tests/unit/network_graph/test_interests.py
+++ b/tests/unit/network_graph/test_interests.py
@@ -172,7 +172,7 @@ def test_interests_path_from_A_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -194,7 +194,7 @@ def test_interests_path_from_A_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
@@ -217,7 +217,7 @@ def test_interests_path_from_A_balance_positive_irrelevant_interests(
     # B owes to A
     # 1% interest given by B to A
 
-    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -239,7 +239,7 @@ def test_interests_path_from_A_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(A, B, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(A, B, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [A, B]
 
 
@@ -261,7 +261,7 @@ def test_interests_path_from_B_balance_positive_relevant_interests(
 ):
     # B owes to A
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == []
 
 
@@ -283,7 +283,7 @@ def test_interests_path_from_B_balance_negative_relevant_interests(
 ):
     # A owes to B
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
@@ -305,7 +305,7 @@ def test_interests_path_from_B_balance_positive_irrelevant_interests(
 ):
     # B owes to A
     # 1% interest given by B to A
-    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]
 
 
@@ -327,5 +327,5 @@ def test_interests_path_from_B_balance_negative_irrelevant_interests(
 ):
     # A owes to B
     # 1% interest given by A to B
-    cost, path = configurable_community.find_path(B, A, 100, timestamp=SECONDS_PER_YEAR)
+    cost, path = configurable_community.find_path_sender_pays_fees(B, A, 100, timestamp=SECONDS_PER_YEAR)
     assert path == [B, A]


### PR DESCRIPTION
Includes the commits from https://github.com/trustlines-network/relay/pull/275.

The diffs is longer than necessary because I had to rebase on develop after the black commit and run black on multiple commits at the same time.

I used a `sender_pays_fees` bool parameter in the API instead of creating a new API to avoid duplication of multiple functions based on the discussion of previous PR.

Closes https://github.com/trustlines-network/relay/issues/271